### PR TITLE
Add a REPL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,10 +22,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anstream"
@@ -63,7 +87,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -73,7 +97,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -120,6 +144,9 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bstr"
@@ -130,6 +157,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
@@ -160,6 +193,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "clap"
@@ -225,12 +271,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "serde",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -250,6 +384,27 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fd-lock"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "fdeflate"
@@ -339,6 +494,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "imagesize"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,11 +540,29 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -390,6 +586,12 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -419,7 +621,7 @@ dependencies = [
  "coordgen",
  "fmtastic",
  "gcd",
- "itertools",
+ "itertools 0.13.0",
  "lazy_static",
  "lock_api",
  "modular-bitfield",
@@ -427,7 +629,9 @@ dependencies = [
  "petgraph",
  "primal",
  "rand",
+ "reedline-repl-rs",
  "resvg",
+ "shlex",
  "small-map",
  "smallvec 2.0.0-alpha.7",
  "thiserror",
@@ -450,6 +654,18 @@ checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -484,6 +700,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +737,29 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.13.2",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "petgraph"
@@ -652,6 +900,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
+name = "reedline"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f8c676a3f3814a23c6a0fc9dff6b6c35b2e04df8134aae6f3929cc34de21a53"
+dependencies = [
+ "chrono",
+ "crossbeam",
+ "crossterm",
+ "fd-lock",
+ "itertools 0.12.1",
+ "nu-ansi-term 0.50.1",
+ "serde",
+ "strip-ansi-escapes",
+ "strum",
+ "strum_macros",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "reedline-repl-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea7d1add283dfbc9373f3997a778e52c7a0af28ae1a039e726cda2c38fd6b548"
+dependencies = [
+ "clap",
+ "crossterm",
+ "nu-ansi-term 0.50.1",
+ "reedline",
+ "regex",
+ "shlex",
+ "winapi-util",
+ "yansi",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
 name = "resvg"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,6 +1002,25 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "rustybuzz"
@@ -729,6 +1071,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -799,10 +1177,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.74",
+]
 
 [[package]]
 name = "svgtypes"
@@ -967,7 +1373,7 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
- "nu-ansi-term",
+ "nu-ansi-term 0.46.0",
  "sharded-slab",
  "smallvec 1.13.2",
  "thread_local",
@@ -1018,10 +1424,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad8d71f5726e5f285a935e9fe8edfd53f0491eb6e9a5774097fdabee7cd8c9cd"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
 name = "unicode-vo"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "usvg"
@@ -1069,10 +1487,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "winapi"
@@ -1091,10 +1584,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1102,7 +1622,22 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1111,15 +1646,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1129,9 +1670,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1147,9 +1700,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1159,9 +1724,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1174,6 +1751,12 @@ name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,20 @@ num-traits = "0.2.19"
 petgraph = "0.6.5"
 primal = "0.3.3"
 rand = { version = "0.8.5", optional = true, features = ["nightly"] }
-resvg = { version = "0.42.0", optional = true, default-features = false, features = ["text"] }
-small-map = { version = "0.1.3", default-features = false, features = ["ahash"] }
+resvg = { version = "0.42.0", optional = true, default-features = false, features = [
+    "text",
+] }
+small-map = { version = "0.1.3", default-features = false, features = [
+    "ahash",
+] }
 smallvec = "2.0.0-alpha.6"
 thiserror = "1.0.63"
 tracing = "0.1.40"
 
 [dev-dependencies]
 clap = { version = "4.5.9", features = ["derive"] }
+reedline-repl-rs = { version = "1.2.1", features = ["shlex"] }
+shlex = "1.3.0"
 tracing-flame = "0.2.0"
 tracing-subscriber = "0.3.18"
 
@@ -41,6 +47,9 @@ name = "arena-test"
 
 [[example]]
 name = "alcohols"
+
+[[example]]
+name = "repl"
 
 [features]
 default = ["coordgen", "rand", "resvg"]

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -1,0 +1,187 @@
+use lute::prelude::*;
+use reedline_repl_rs::{self as rlr, Repl};
+use rlr::clap::{self, Arg, ArgAction, ArgMatches, Command};
+use clap::builder::PossibleValue;
+use std::convert::Infallible;
+use std::path::PathBuf;
+use std::env;
+use thiserror::Error;
+use tracing_subscriber::filter::{LevelFilter, ParseError, Targets};
+use tracing_subscriber::fmt::{self, format::*};
+use tracing_subscriber::prelude::*;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum DumpType {
+    FastSmiles,
+    CanonSmiles,
+    #[cfg(feature = "coordgen")]
+    Svg,
+    #[cfg(all(feature = "coordgen", feature = "resvg"))]
+    Png,
+}
+impl clap::ValueEnum for DumpType {
+    #[allow(unreachable_code)]
+    fn value_variants<'a>() -> &'a [Self] {
+        #[cfg(feature = "coordgen")]
+        {
+            #[cfg(feature = "resvg")]
+            return &[Self::FastSmiles, Self::CanonSmiles, Self::Svg, Self::Png];
+            return &[Self::FastSmiles, Self::CanonSmiles, Self::Svg]
+        }
+        &[Self::FastSmiles, Self::CanonSmiles]
+    }
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        match self {
+            Self::FastSmiles => Some(PossibleValue::new("fast-smiles")),
+            Self::CanonSmiles => Some(PossibleValue::new("canon-smiles").alias("smiles")),
+            #[cfg(feature = "coordgen")]
+            Self::Svg => Some(PossibleValue::new("svg")),
+            #[cfg(all(feature = "coordgen", feature = "resvg"))]
+            Self::Png => Some(PossibleValue::new("png")),
+        }
+    }
+
+}
+
+#[derive(Debug, Error)]
+enum ReplError {
+    #[error(transparent)]
+    Repl(#[from] rlr::Error),
+    #[error(transparent)]
+    Tracing(#[from] ParseError),
+    #[error(transparent)]
+    StdIo(#[from] std::io::Error),
+    #[error("{}{err}", if *.index == 0 { String::new() } else { format!("Error in input #{index}: ") })]
+    Smiles {
+        index: usize,
+        err: lute::parse::smiles::SmilesError,
+    },
+}
+
+type SubscriberType = tracing_subscriber::layer::Layered<
+    Targets,
+    fmt::Subscriber<DefaultFields, Format<Full>, LevelFilter, fn() -> std::io::Stderr>,
+>;
+
+struct Context {
+    arena: Arena<u32>,
+    trace: SubscriberType,
+}
+
+fn default_subscriber() -> SubscriberType {
+    fmt::fmt()
+        .with_writer(std::io::stderr as _)
+        .finish()
+        .with(Targets::new())
+}
+
+fn make_subscriber(filter: &str) -> Result<SubscriberType, ParseError> {
+    use std::str::FromStr;
+    Ok(fmt::fmt()
+        .with_writer(std::io::stderr as _)
+        .finish()
+        .with(Targets::from_str(filter)?))
+}
+
+fn set_log(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError> {
+    ctx.trace = make_subscriber(args.get_one::<String>("filter").unwrap())?;
+    Ok(None)
+}
+
+fn load_smiles(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError> {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let inputs = args.get_many::<String>("input").unwrap();
+    let len = inputs.len();
+    for (n, arg) in inputs.enumerate() {
+        let graph = SmilesParser::new(arg)
+            .parse()
+            .map_err(|err| ReplError::Smiles {
+                err,
+                index: if len == 1 { 0 } else { len },
+            })?;
+        let id = ctx.arena.insert_mol(&graph);
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        let _ = write!(out, "{id}");
+    }
+    Ok(Some(out))
+}
+
+fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError> {
+    let path = args.get_one::<PathBuf>("out");
+    match args.get_one::<DumpType>("type").unwrap() {
+        ty @ (DumpType::CanonSmiles | DumpType::FastSmiles) => {
+            let cfg = if *ty == DumpType::FastSmiles {
+                SmilesConfig::fast_roundtrip()
+            } else {
+                SmilesConfig::new()
+            };
+            let s = if let Some(inputs) = args.get_many::<u32>("input") {
+                todo!()
+            } else {
+                generate_smiles(ctx.arena.graph(), cfg)
+            };
+            if let Some(p) = path {
+                std::fs::write(&p, s)?;
+                Ok(Some(format!("saved to {}", p.display())))
+            } else {
+                Ok(Some(s))
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn main() {
+    let trace = match env::var("LUTE_LOG") {
+        Ok(name) => {
+            make_subscriber(&name).unwrap_or_else(|e| {
+                eprintln!("Error in LUTE_LOG environment variable: {e}");
+                default_subscriber()
+            })
+        }
+        Err(env::VarError::NotPresent) => default_subscriber(),
+        Err(env::VarError::NotUnicode(_)) => {
+            eprintln!("Error in LUTE_LOG environment variable: not valid UTF-8");
+            default_subscriber()
+        }
+    };
+    let context = Context {
+        arena: Arena::new(),
+        trace,
+    };
+    let mut repl = Repl::new(context)
+        .with_name("Lute")
+        .with_command(Command::new("reset").about("Reset the arena"), |_, ctx| {
+            ctx.arena = Arena::new();
+            Ok(None)
+        })
+        .with_command(
+            Command::new("log")
+                .about("Set the log filter")
+                .arg(Arg::new("filter").required(true)),
+            set_log,
+        )
+        .with_command(
+            Command::new("load")
+                .about("Load SMILES inputs")
+                .arg(Arg::new("input").required(true).action(ArgAction::Append)),
+            load_smiles,
+        )
+        .with_command(
+            Command::new("dump")
+                .about("Show the output of inputs, or the whole graph if no ids are given")
+                .arg(Arg::new("type").required(true).value_parser(clap::value_parser!(DumpType)))
+                .arg(Arg::new("out").short('o').long("output").value_parser(clap::value_parser!(PathBuf)))
+                .arg(
+                    Arg::new("input")
+                        .required(false)
+                        .action(ArgAction::Append)
+                        .value_parser(clap::value_parser!(u32)),
+                ),
+            dump,
+        );
+    repl.run();
+}

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -1,10 +1,14 @@
+use clap::builder::PossibleValue;
+use lute::graph::*;
 use lute::prelude::*;
+use petgraph::prelude::*;
 use reedline_repl_rs::{self as rlr, Repl};
 use rlr::clap::{self, Arg, ArgAction, ArgMatches, Command};
-use clap::builder::PossibleValue;
-use std::convert::Infallible;
-use std::path::PathBuf;
 use std::env;
+use std::ffi::OsStr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
 use thiserror::Error;
 use tracing_subscriber::filter::{LevelFilter, ParseError, Targets};
 use tracing_subscriber::fmt::{self, format::*};
@@ -26,7 +30,7 @@ impl clap::ValueEnum for DumpType {
         {
             #[cfg(feature = "resvg")]
             return &[Self::FastSmiles, Self::CanonSmiles, Self::Svg, Self::Png];
-            return &[Self::FastSmiles, Self::CanonSmiles, Self::Svg]
+            return &[Self::FastSmiles, Self::CanonSmiles, Self::Svg];
         }
         &[Self::FastSmiles, Self::CanonSmiles]
     }
@@ -40,7 +44,6 @@ impl clap::ValueEnum for DumpType {
             Self::Png => Some(PossibleValue::new("png")),
         }
     }
-
 }
 
 #[derive(Debug, Error)]
@@ -56,6 +59,100 @@ enum ReplError {
         index: usize,
         err: lute::parse::smiles::SmilesError,
     },
+    #[error("Attempted to generate a PNG of a molecule without an output path")]
+    PngToStdout,
+    /// other stuff I don't wanna name
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FlagKind {
+    Enable,
+    Disable,
+    Query,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FlagName {
+    Timings,
+    LegacyRender,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SetParser;
+impl clap::builder::TypedValueParser for SetParser {
+    type Value = (FlagKind, FlagName);
+
+    fn parse_ref(
+        &self,
+        cmd: &Command,
+        _arg: Option<&Arg>,
+        value: &OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        use clap::error::*;
+        let val = value
+            .to_str()
+            .ok_or_else(|| Error::new(ErrorKind::InvalidUtf8).with_cmd(cmd))?;
+        let mode = match val.as_bytes().get(0) {
+            Some(&b'+') => FlagKind::Enable,
+            Some(&b'-') => FlagKind::Disable,
+            Some(&b'?') => FlagKind::Query,
+            _ => {
+                let mut err = Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
+                err.insert(ContextKind::InvalidValue, ContextValue::String(val.to_string()));
+                err.insert(
+                    ContextKind::Usage,
+                    ContextValue::StyledStr(
+                        "Make sure the argument starts with '+', '-', or '?'".into(),
+                    ),
+                );
+                return Err(err);
+            }
+        };
+        let name = match &val[1..] {
+            "timings" => FlagName::Timings,
+            "legacy-render" | "legacy_render" => FlagName::LegacyRender,
+            _ => {
+                let mut err = Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
+                err.insert(ContextKind::InvalidValue, ContextValue::String(val.to_string()));
+                err.insert(
+                    ContextKind::Usage,
+                    ContextValue::StyledStr(
+                        r#"Available flags are "timings" and "legacy-render""#.into(),
+                    ),
+                );
+                return Err(err);
+            }
+        };
+        Ok((mode, name))
+    }
+    fn possible_values(&self) -> Option<Box<dyn Iterator<Item = PossibleValue>>> {
+        Some(
+            Box::new([
+                PossibleValue::new("+timings").hide(true),
+                PossibleValue::new("-timings").hide(true),
+                PossibleValue::new("?timings"),
+                PossibleValue::new("+legacy-render").alias("+legacy_render").hide(true),
+                PossibleValue::new("-legacy-render").alias("-legacy_render").hide(true),
+                PossibleValue::new("?legacy-render").alias("?legacy_render"),
+            ]
+            .into_iter()),
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Timer(Instant);
+impl Timer {
+    pub fn new() -> Self {
+        Self(Instant::now())
+    }
+}
+impl Drop for Timer {
+    fn drop(&mut self) {
+        println!("{:?}", self.0.elapsed());
+    }
 }
 
 type SubscriberType = tracing_subscriber::layer::Layered<
@@ -65,7 +162,9 @@ type SubscriberType = tracing_subscriber::layer::Layered<
 
 struct Context {
     arena: Arena<u32>,
-    trace: SubscriberType,
+    trace: Arc<SubscriberType>,
+    timings: bool,
+    legacy_render: bool,
 }
 
 fn default_subscriber() -> SubscriberType {
@@ -84,12 +183,20 @@ fn make_subscriber(filter: &str) -> Result<SubscriberType, ParseError> {
 }
 
 fn set_log(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError> {
-    ctx.trace = make_subscriber(args.get_one::<String>("filter").unwrap())?;
-    Ok(None)
+    if let Some(filter) = args.get_one::<String>("filter") {
+        ctx.trace = Arc::new(make_subscriber(filter)?);
+        Ok(None)
+    } else {
+        Ok(Some(
+            ctx.trace.downcast_ref::<Targets>().unwrap().to_string(),
+        ))
+    }
 }
 
 fn load_smiles(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError> {
     use std::fmt::Write;
+    let _guard = tracing::subscriber::set_default(ctx.trace.clone());
+    let _timer = ctx.timings.then(Timer::new);
     let mut out = String::new();
     let inputs = args.get_many::<String>("input").unwrap();
     let len = inputs.len();
@@ -98,7 +205,7 @@ fn load_smiles(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, Re
             .parse()
             .map_err(|err| ReplError::Smiles {
                 err,
-                index: if len == 1 { 0 } else { len },
+                index: if len == 1 { 0 } else { n },
             })?;
         let id = ctx.arena.insert_mol(&graph);
         if !out.is_empty() {
@@ -110,6 +217,8 @@ fn load_smiles(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, Re
 }
 
 fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError> {
+    let _guard = tracing::subscriber::set_default(ctx.trace.clone());
+    let _timer = ctx.timings.then(Timer::new);
     let path = args.get_one::<PathBuf>("out");
     match args.get_one::<DumpType>("type").unwrap() {
         ty @ (DumpType::CanonSmiles | DumpType::FastSmiles) => {
@@ -119,7 +228,10 @@ fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError
                 SmilesConfig::new()
             };
             let s = if let Some(inputs) = args.get_many::<u32>("input") {
-                todo!()
+                generate_smiles(
+                    &GraphUnion(inputs.map(|i| ctx.arena.molecule(*i)).collect()),
+                    cfg,
+                )
             } else {
                 generate_smiles(ctx.arena.graph(), cfg)
             };
@@ -130,18 +242,93 @@ fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError
                 Ok(Some(s))
             }
         }
-        _ => unreachable!(),
+        #[cfg(feature = "coordgen")]
+        DumpType::Svg => {
+            use lute::disp::svg::FormatMode;
+            let mode = if ctx.legacy_render {
+                FormatMode::LegacyH
+            } else {
+                FormatMode::Normal
+            };
+            let s = if let Some(inputs) = args.get_many::<u32>("input") {
+                SvgFormatter {
+                    graph: &GraphUnion(inputs.map(|i| ctx.arena.molecule(*i)).collect()),
+                    mode,
+                }
+                .to_string()
+            } else {
+                SvgFormatter {
+                    graph: &GraphCompactor::<&StableUnGraph<Atom, Bond>>::new(ctx.arena.graph()),
+                    mode,
+                }
+                .to_string()
+            };
+            if let Some(p) = path {
+                std::fs::write(&p, s)?;
+                Ok(Some(format!("saved to {}", p.display())))
+            } else {
+                Ok(Some(s))
+            }
+        }
+        #[cfg(all(feature = "coordgen", feature = "resvg"))]
+        DumpType::Png => {
+            use lute::disp::svg::FormatMode;
+            let mode = if ctx.legacy_render {
+                FormatMode::LegacyH
+            } else {
+                FormatMode::Normal
+            };
+            let s = if let Some(inputs) = args.get_many::<u32>("input") {
+                SvgFormatter {
+                    graph: &GraphUnion(inputs.map(|i| ctx.arena.molecule(*i)).collect()),
+                    mode,
+                }
+                .render(None)
+            } else {
+                SvgFormatter {
+                    graph: &GraphCompactor::<&StableUnGraph<Atom, Bond>>::new(ctx.arena.graph()),
+                    mode,
+                }
+                .render(None)
+            };
+            if let Some(p) = path {
+                s.save_png(&p).map_err(Box::from)?;
+                Ok(Some(format!("saved to {}", p.display())))
+            } else {
+                Err(ReplError::PngToStdout)
+            }
+        }
     }
+}
+
+fn adjust_settings(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError> {
+    use std::fmt::Write;
+    let mut out = String::new();
+    for (act, name) in args.get_many::<(FlagKind, FlagName)>("settings").unwrap() {
+        let flag = match name {
+            FlagName::Timings => &mut ctx.timings,
+            FlagName::LegacyRender => &mut ctx.legacy_render,
+        };
+        match act {
+            FlagKind::Enable => *flag = true,
+            FlagKind::Disable => *flag = false,
+            FlagKind::Query => {
+                if out.is_empty() {
+                    out.push(' ');
+                    let _ = write!(out, "{flag}");
+                }
+            }
+        }
+    }
+    Ok(Some(out))
 }
 
 fn main() {
     let trace = match env::var("LUTE_LOG") {
-        Ok(name) => {
-            make_subscriber(&name).unwrap_or_else(|e| {
-                eprintln!("Error in LUTE_LOG environment variable: {e}");
-                default_subscriber()
-            })
-        }
+        Ok(name) => make_subscriber(&name).unwrap_or_else(|e| {
+            eprintln!("Error in LUTE_LOG environment variable: {e}");
+            default_subscriber()
+        }),
         Err(env::VarError::NotPresent) => default_subscriber(),
         Err(env::VarError::NotUnicode(_)) => {
             eprintln!("Error in LUTE_LOG environment variable: not valid UTF-8");
@@ -150,10 +337,14 @@ fn main() {
     };
     let context = Context {
         arena: Arena::new(),
-        trace,
+        trace: Arc::new(trace),
+        timings: false,
+        legacy_render: false,
     };
     let mut repl = Repl::new(context)
-        .with_name("Lute")
+        .with_name("lute")
+        .with_version(concat!("v", env!("CARGO_PKG_VERSION")))
+        .with_prompt(concat!("lute v", env!("CARGO_PKG_VERSION")))
         .with_command(Command::new("reset").about("Reset the arena"), |_, ctx| {
             ctx.arena = Arena::new();
             Ok(None)
@@ -161,27 +352,54 @@ fn main() {
         .with_command(
             Command::new("log")
                 .about("Set the log filter")
-                .arg(Arg::new("filter").required(true)),
+                .arg(Arg::new("filter").required(false).help("The filter string to use")),
             set_log,
         )
         .with_command(
             Command::new("load")
                 .about("Load SMILES inputs")
-                .arg(Arg::new("input").required(true).action(ArgAction::Append)),
+                .arg(Arg::new("input").required(true).action(ArgAction::Append).help("SMILES inputs to load")),
             load_smiles,
         )
         .with_command(
             Command::new("dump")
                 .about("Show the output of inputs, or the whole graph if no ids are given")
-                .arg(Arg::new("type").required(true).value_parser(clap::value_parser!(DumpType)))
-                .arg(Arg::new("out").short('o').long("output").value_parser(clap::value_parser!(PathBuf)))
+                .arg(
+                    Arg::new("type")
+                        .required(true)
+                        .value_parser(clap::value_parser!(DumpType))
+                        .help("Output format to dump as"),
+                )
+                .arg(
+                    Arg::new("out")
+                        .short('o')
+                        .long("output")
+                        .value_name("FILE")
+                        .value_parser(clap::value_parser!(PathBuf))
+                        .help("The file to output to"),
+                )
                 .arg(
                     Arg::new("input")
                         .required(false)
                         .action(ArgAction::Append)
-                        .value_parser(clap::value_parser!(u32)),
+                        .value_name("IDS")
+                        .value_parser(clap::value_parser!(u32))
+                        .help("Fragment IDs to dump"),
                 ),
             dump,
+        )
+        .with_command(
+            Command::new("set").about("Adjust REPL settings").arg(
+                Arg::new("settings")
+                    .required(true)
+                    .action(ArgAction::Append)
+                    .allow_hyphen_values(true)
+                    .value_parser(clap::builder::ValueParser::new(SetParser)),
+            ),
+            adjust_settings,
         );
-    repl.run();
+    let res = repl.run();
+    if let Err(err) = res {
+        eprintln!("{err}");
+    }
 }

--- a/src/arena/molecule/node_impls.rs
+++ b/src/arena/molecule/node_impls.rs
@@ -116,6 +116,7 @@ impl<Ix> NodeReference<Ix> {
     where
         Ix: IndexType,
     {
+        println!("mi: {}, ni: {}", mol_idx.index(), node_idx.0.index());
         Self {
             node_idx,
             atom: arena

--- a/src/graph/graph_union.rs
+++ b/src/graph/graph_union.rs
@@ -1,0 +1,318 @@
+use crate::prelude::DataValueMap;
+use petgraph::data::*;
+use petgraph::visit::*;
+use petgraph::Direction;
+
+/// A union of multiple graphs that acts as one, disconnected graph.
+#[derive(Debug, Default, Clone)]
+pub struct GraphUnion<G>(pub Vec<G>);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Tagged<I> {
+    graph_id: usize,
+    inner: I,
+}
+impl<I: NodeRef> NodeRef for Tagged<I> {
+    type NodeId = Tagged<I::NodeId>;
+    type Weight = I::Weight;
+
+    fn id(&self) -> Self::NodeId {
+        Tagged {
+            graph_id: self.graph_id,
+            inner: self.inner.id(),
+        }
+    }
+    fn weight(&self) -> &Self::Weight {
+        self.inner.weight()
+    }
+}
+impl<I: EdgeRef> EdgeRef for Tagged<I> {
+    type NodeId = Tagged<I::NodeId>;
+    type EdgeId = Tagged<I::EdgeId>;
+    type Weight = I::Weight;
+
+    fn id(&self) -> Self::EdgeId {
+        Tagged {
+            graph_id: self.graph_id,
+            inner: self.inner.id(),
+        }
+    }
+    fn source(&self) -> Self::NodeId {
+        Tagged {
+            graph_id: self.graph_id,
+            inner: self.inner.source(),
+        }
+    }
+    fn target(&self) -> Self::NodeId {
+        Tagged {
+            graph_id: self.graph_id,
+            inner: self.inner.target(),
+        }
+    }
+    fn weight(&self) -> &Self::Weight {
+        self.inner.weight()
+    }
+}
+
+impl<G: GraphBase> GraphBase for GraphUnion<G> {
+    type NodeId = Tagged<G::NodeId>;
+    type EdgeId = Tagged<G::EdgeId>;
+}
+impl<G: GraphProp> GraphProp for GraphUnion<G> {
+    type EdgeType = G::EdgeType;
+}
+impl<G: Data> Data for GraphUnion<G> {
+    type NodeWeight = G::NodeWeight;
+    type EdgeWeight = G::EdgeWeight;
+}
+impl<G: DataMap> DataMap for GraphUnion<G> {
+    fn node_weight(&self, id: Tagged<G::NodeId>) -> Option<&G::NodeWeight> {
+        self.0[id.graph_id].node_weight(id.inner)
+    }
+    fn edge_weight(&self, id: Tagged<G::EdgeId>) -> Option<&G::EdgeWeight> {
+        self.0[id.graph_id].edge_weight(id.inner)
+    }
+}
+impl<G: DataMapMut> DataMapMut for GraphUnion<G> {
+    fn node_weight_mut(&mut self, id: Tagged<G::NodeId>) -> Option<&mut G::NodeWeight> {
+        self.0[id.graph_id].node_weight_mut(id.inner)
+    }
+    fn edge_weight_mut(&mut self, id: Tagged<G::EdgeId>) -> Option<&mut G::EdgeWeight> {
+        self.0[id.graph_id].edge_weight_mut(id.inner)
+    }
+}
+impl<G: DataValueMap> DataValueMap for GraphUnion<G> {
+    fn node_weight(&self, id: Tagged<G::NodeId>) -> Option<G::NodeWeight> {
+        self.0[id.graph_id].node_weight(id.inner)
+    }
+    fn edge_weight(&self, id: Tagged<G::EdgeId>) -> Option<G::EdgeWeight> {
+        self.0[id.graph_id].edge_weight(id.inner)
+    }
+}
+impl<G: NodeCount> NodeCount for GraphUnion<G> {
+    fn node_count(&self) -> usize {
+        self.0.iter().map(G::node_count).sum()
+    }
+}
+impl<G: EdgeCount> EdgeCount for GraphUnion<G> {
+    fn edge_count(&self) -> usize {
+        self.0.iter().map(G::edge_count).sum()
+    }
+}
+impl<G: NodeIndexable> NodeIndexable for GraphUnion<G> {
+    fn to_index(&self, a: Self::NodeId) -> usize {
+        (0..a.graph_id)
+            .map(|i| self.0[i].node_bound())
+            .sum::<usize>()
+            + self.0[a.graph_id].to_index(a.inner)
+    }
+    fn from_index(&self, mut i: usize) -> Self::NodeId {
+        let mut graph_id = 0;
+        for g in &self.0 {
+            if let Some(i2) = i.checked_sub(g.node_bound()) {
+                i = i2;
+                graph_id += 1;
+            } else {
+                break;
+            }
+        }
+        Self::NodeId {
+            graph_id,
+            inner: self.0[graph_id].from_index(i),
+        }
+    }
+    fn node_bound(&self) -> usize {
+        self.0.iter().map(G::node_bound).sum()
+    }
+}
+impl<G: EdgeIndexable> EdgeIndexable for GraphUnion<G> {
+    fn to_index(&self, a: Self::EdgeId) -> usize {
+        (0..a.graph_id)
+            .map(|i| self.0[i].edge_bound())
+            .sum::<usize>()
+            + self.0[a.graph_id].to_index(a.inner)
+    }
+    fn from_index(&self, mut i: usize) -> Self::EdgeId {
+        let mut graph_id = 0;
+        for g in &self.0 {
+            if let Some(i2) = i.checked_sub(g.edge_bound()) {
+                i = i2;
+                graph_id += 1;
+            } else {
+                break;
+            }
+        }
+        Self::EdgeId {
+            graph_id,
+            inner: self.0[graph_id].from_index(i),
+        }
+    }
+    fn edge_bound(&self) -> usize {
+        self.0.iter().map(G::edge_bound).sum()
+    }
+}
+impl<G: NodeCompactIndexable> NodeCompactIndexable for GraphUnion<G> {}
+
+impl<'a, G: GraphBase> IntoNodeIdentifiers for &'a GraphUnion<G>
+where
+    &'a G: IntoNodeIdentifiers<NodeId = G::NodeId>,
+{
+    type NodeIdentifiers = iter::TaggedIter<'a, G, <&'a G as IntoNodeIdentifiers>::NodeIdentifiers>;
+
+    fn node_identifiers(self) -> Self::NodeIdentifiers {
+        iter::TaggedIter {
+            graphs: &self.0,
+            index: 0,
+            iter: self.0.first().map(IntoNodeIdentifiers::node_identifiers),
+            map: IntoNodeIdentifiers::node_identifiers,
+        }
+    }
+}
+impl<'a, G: Data> IntoNodeReferences for &'a GraphUnion<G>
+where
+    &'a G: IntoNodeReferences<NodeId = G::NodeId, NodeWeight = G::NodeWeight>,
+{
+    type NodeRef = Tagged<<&'a G as IntoNodeReferences>::NodeRef>;
+    type NodeReferences = iter::TaggedIter<'a, G, <&'a G as IntoNodeReferences>::NodeReferences>;
+
+    fn node_references(self) -> Self::NodeReferences {
+        iter::TaggedIter {
+            graphs: &self.0,
+            index: 0,
+            iter: self.0.first().map(IntoNodeReferences::node_references),
+            map: IntoNodeReferences::node_references,
+        }
+    }
+}
+impl<'a, G: Data> IntoEdgeReferences for &'a GraphUnion<G>
+where
+    &'a G: IntoEdgeReferences<NodeId = G::NodeId, EdgeId = G::EdgeId, EdgeWeight = G::EdgeWeight>,
+{
+    type EdgeRef = Tagged<<&'a G as IntoEdgeReferences>::EdgeRef>;
+    type EdgeReferences = iter::TaggedIter<'a, G, <&'a G as IntoEdgeReferences>::EdgeReferences>;
+
+    fn edge_references(self) -> Self::EdgeReferences {
+        iter::TaggedIter {
+            graphs: &self.0,
+            index: 0,
+            iter: self.0.first().map(IntoEdgeReferences::edge_references),
+            map: IntoEdgeReferences::edge_references,
+        }
+    }
+}
+impl<'a, G: GraphBase> IntoNeighbors for &'a GraphUnion<G>
+where
+    &'a G: IntoNeighbors<NodeId = G::NodeId>,
+{
+    type Neighbors = iter::MappedIter<<&'a G as IntoNeighbors>::Neighbors>;
+
+    fn neighbors(self, a: Self::NodeId) -> Self::Neighbors {
+        iter::MappedIter {
+            graph_id: a.graph_id,
+            iter: self.0[a.graph_id].neighbors(a.inner),
+        }
+    }
+}
+impl<'a, G: GraphBase> IntoNeighborsDirected for &'a GraphUnion<G>
+where
+    &'a G: IntoNeighborsDirected<NodeId = G::NodeId>,
+{
+    type NeighborsDirected = iter::MappedIter<<&'a G as IntoNeighborsDirected>::NeighborsDirected>;
+
+    fn neighbors_directed(self, a: Self::NodeId, dir: Direction) -> Self::NeighborsDirected {
+        iter::MappedIter {
+            graph_id: a.graph_id,
+            iter: self.0[a.graph_id].neighbors_directed(a.inner, dir),
+        }
+    }
+}
+impl<'a, G: Data> IntoEdges for &'a GraphUnion<G>
+where
+    &'a G: IntoEdges<NodeId = G::NodeId, EdgeId = G::EdgeId, EdgeWeight = G::EdgeWeight>,
+{
+    type Edges = iter::MappedIter<<&'a G as IntoEdges>::Edges>;
+
+    fn edges(self, a: Self::NodeId) -> Self::Edges {
+        iter::MappedIter {
+            graph_id: a.graph_id,
+            iter: self.0[a.graph_id].edges(a.inner),
+        }
+    }
+}
+impl<'a, G: Data> IntoEdgesDirected for &'a GraphUnion<G>
+where
+    &'a G: IntoEdgesDirected<NodeId = G::NodeId, EdgeId = G::EdgeId, EdgeWeight = G::EdgeWeight>,
+{
+    type EdgesDirected = iter::MappedIter<<&'a G as IntoEdgesDirected>::EdgesDirected>;
+
+    fn edges_directed(self, a: Self::NodeId, dir: Direction) -> Self::EdgesDirected {
+        iter::MappedIter {
+            graph_id: a.graph_id,
+            iter: self.0[a.graph_id].edges_directed(a.inner, dir),
+        }
+    }
+}
+impl<G: Visitable> Visitable for GraphUnion<G> {
+    type Map = UnionVisitMap<G::Map>;
+
+    fn visit_map(&self) -> Self::Map {
+        UnionVisitMap(self.0.iter().map(G::visit_map).collect())
+    }
+    fn reset_map(&self, map: &mut Self::Map) {
+        self.0
+            .iter()
+            .zip(&mut map.0)
+            .for_each(|(g, m)| g.reset_map(m));
+    }
+}
+
+pub struct UnionVisitMap<M>(Vec<M>);
+impl<N, M: VisitMap<N>> VisitMap<Tagged<N>> for UnionVisitMap<M> {
+    fn visit(&mut self, a: Tagged<N>) -> bool {
+        self.0[a.graph_id].visit(a.inner)
+    }
+    fn is_visited(&self, a: &Tagged<N>) -> bool {
+        self.0[a.graph_id].is_visited(&a.inner)
+    }
+}
+
+#[doc(hidden)]
+pub mod iter {
+    use super::*;
+    pub struct TaggedIter<'a, G, I> {
+        pub(super) graphs: &'a [G],
+        pub(super) index: usize,
+        pub(super) iter: Option<I>,
+        pub(super) map: fn(&'a G) -> I,
+    }
+    impl<'a, G, I: Iterator> Iterator for TaggedIter<'a, G, I> {
+        type Item = Tagged<I::Item>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            loop {
+                if let Some(elem) = self.iter.as_mut()?.next() {
+                    return Some(Tagged {
+                        graph_id: self.index,
+                        inner: elem,
+                    });
+                }
+                self.index += 1;
+                self.iter = self.graphs.get(self.index).map(self.map);
+            }
+        }
+    }
+    pub struct MappedIter<I> {
+        pub(super) graph_id: usize,
+        pub(super) iter: I,
+    }
+    impl<I: Iterator> Iterator for MappedIter<I> {
+        type Item = Tagged<I::Item>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.iter.next().map(|inner| Tagged {
+                graph_id: self.graph_id,
+                inner,
+            })
+        }
+    }
+}

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -3,6 +3,7 @@
 pub mod algo;
 pub mod bitfilter;
 pub mod compact;
+pub mod graph_union;
 pub mod misc;
 pub mod modded;
 pub mod nodefilter;
@@ -10,5 +11,6 @@ pub mod nodefilter;
 pub use algo::*;
 pub use bitfilter::BitFiltered;
 pub use compact::GraphCompactor;
+pub use graph_union::GraphUnion;
 pub use modded::ModdedGraph;
 pub use nodefilter::NodeFilter;


### PR DESCRIPTION
For a lot of development, it would be easier to check small things without having to recompile full programs. This adds a `repl` example that can process simple commands to manipulate an arena.