### PR TITLE
Rewrite the `Arena::insert` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
  "primal",
  "rand",
  "resvg",
+ "slab",
  "small-map",
  "smallvec 2.0.0-alpha.7",
  "thiserror",
@@ -751,6 +752,15 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "slotmap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ petgraph = "0.6.5"
 primal = "0.3.3"
 rand = { version = "0.8.5", optional = true, features = ["nightly"] }
 resvg = { version = "0.42.0", optional = true, default-features = false, features = ["text"] }
+slab = "0.4.9"
 small-map = { version = "0.1.3", default-features = false, features = ["ahash"] }
 smallvec = "2.0.0-alpha.6"
 thiserror = "1.0.63"

--- a/src/arena/arena.rs
+++ b/src/arena/arena.rs
@@ -314,10 +314,11 @@ impl<Ix: IndexType> Arena<Ix> {
             }
             if !found_any {
                 prune_buf.clear();
+                prune_buf.push((i, false));
                 frags.retain(|&(n, p)| {
-                    prune_buf.iter().rev().any(|(i, _)| p.contains(i)) && {
+                    !prune_buf.iter().rev().any(|(i, _)| p.contains(i)) || {
                         prune_buf.push((Ix::new(n), false));
-                        true
+                        false
                     }
                 });
             }

--- a/src/arena/arena.rs
+++ b/src/arena/arena.rs
@@ -7,8 +7,9 @@ use crate::graph::*;
 use petgraph::graph::DefaultIx;
 use petgraph::prelude::*;
 use petgraph::visit::*;
-use small_map::ASmallMap;
+use slab::Slab;
 use smallvec::SmallVec;
+use std::cell::{Cell, UnsafeCell};
 use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -101,17 +102,29 @@ impl<Ix: IndexType> Arena<Ix> {
         Ix::new(idx)
     }
 
-    /// Check if `mol` contains `group`
-    #[instrument(level = "trace", skip(self))]
     pub fn contains_group(&self, mol: Ix, group: Ix) -> bool {
+        let mut stack = SmallVec::<_, 3>::new();
+        let mut seen = BSType::new();
+        self.contains_group_impl(mol, group, &mut stack, &mut seen)
+    }
+
+    /// Check if `mol` contains `group`
+    #[instrument(level = "trace", name = "contains_group", skip(self))]
+    fn contains_group_impl(
+        &self,
+        mol: Ix,
+        group: Ix,
+        stack: &mut SmallVec<Ix, 3>,
+        seen: &mut BSType,
+    ) -> bool {
+        stack.clear();
+        seen.clear();
         // if mol.index() < group.index() {
         //     return false; // quirk of insertion order
         // }
         if mol.index() >= self.parts.len() || group.index() >= self.parts.len() {
             return false;
         }
-        let mut stack = SmallVec::<_, 3>::new();
-        let mut seen = BSType::new();
         stack.push(mol);
         while let Some(i) = stack.pop() {
             let idx = i.index();
@@ -138,15 +151,12 @@ impl<Ix: IndexType> Arena<Ix> {
         Molecule::from_arena(self, mol)
     }
 
-    /// Simpler, faster version of `insert_mol` for when we know there are no subgraphs
-    /// Returns index and mapping where forall `i`:
-    /// `self.molecule(ix).get_atom(i) == mol.get_node(mapping[i])`
-    ///
-    /// Checks for isomorpisms iff `find_isms`
-    fn insert_mol_atomic<G>(
+    /// Insert a molecule into the arena, deduplicating common parts.
+    fn insert_mol_impl<G>(
         &mut self,
         mol: G,
-        find_isms: bool,
+        isms_from: usize,
+        bits: Option<&mut BSType>,
     ) -> (Ix, Vec<usize>)
     where
         G: Data<NodeWeight = Atom, EdgeWeight = Bond>
@@ -158,136 +168,27 @@ impl<Ix: IndexType> Arena<Ix> {
             + IntoNodeReferences,
         G::NodeId: Hash + Eq,
     {
-        let mut mods = SmallVec::<(Ix, Atom), 4>::with_capacity(mol.node_count());
-        let mut node_map = vec![usize::MAX; mol.node_count()];
-        if find_isms {
-            let _guard = debug_span!("checking for isomorphic fragments").entered();
-            let frags = self
-                .parts
-                .iter()
-                .enumerate()
-                .filter_map(|(n, p)| {
-                    (p.1.index() == mol.node_count() && matches!(p.0, MolRepr::Atomic(_)))
-                        .then_some(n)
-                })
-                .collect::<SmallVec<_, 4>>();
-            debug!(?frags, "found available fragments");
-            let mut amatch = Atom::matches;
-            let mut bmatch = PartialEq::eq;
-            let mut best: Option<(Ix, SmallVec<_, 4>, Vec<_>)> = None;
-            for &i in &frags {
-                debug!(idx = i, "matching fragment");
-                let cmp = self.molecule(Ix::new(i));
-                for ism in isomorphisms_iter(&cmp, &mol, &mut amatch, &mut bmatch, false) {
-                    debug_assert_eq!(ism.len(), mol.node_count());
-                    mods.clear();
-
-                    for (cmp_i, &mol_i) in ism.iter().enumerate() {
-                        let graph_atom = cmp.get_atom(Ix::new(cmp_i)).unwrap();
-                        let mol_atom = mol.node_weight(mol.from_index(mol_i)).unwrap();
-                        if graph_atom != mol_atom {
-                            let mi = Ix::new(mol_i);
-                            if let Err(idx) = mods.binary_search_by_key(&mi, |m| m.0) {
-                                mods.insert(idx, (mi, mol_atom));
-                            }
-                        }
-                        node_map[mol_i] = cmp_i;
-                    }
-
-                    // perfect match!
-                    if mods.is_empty() {
-                        info!(idx = i, ?node_map, "perfect isomorphism");
-                        return (Ix::new(i), node_map);
-                    }
-
-                    // not quite perfect, let's see if there's already another modded mol
-                    for (idx, frag) in self.parts.iter().enumerate() {
-                        if let MolRepr::Modify(m) = &frag.0 {
-                            if m.base.index() == i && m.patch == mods {
-                                info!(idx, base = i, ?node_map, "matched isomorphism");
-                                return (Ix::new(idx), node_map);
-                            }
-                        }
-                    }
-                    if let Some((ix, ms, nm)) = &mut best {
-                        if mods.len() < ms.len() {
-                            // reusing allocations!
-                            *ix = Ix::new(i);
-                            ms.clear();
-                            ms.extend_from_slice(&mods); // this is a SmallVec, it uses Copy
-                            nm.copy_from_slice(&node_map);
-                        }
-                    } else {
-                        best = Some((Ix::new(i), mods.clone(), node_map.clone()));
-                    }
-                }
-            }
-            if let Some((base, patch, node_map)) = best {
-                let frag = MolRepr::Modify(ModdedMol { base, patch });
-                return (self.push_frag((frag, Ix::new(mol.node_count()))), node_map);
-            }
-        }
-        let end = petgraph::graph::NodeIndex::<Ix>::end();
-        let mut bits = BSType::new();
-        let mut node_map = vec![end; mol.node_bound()];
-        let mut atom_map = Vec::with_capacity(mol.node_bound());
-        for aref in mol.node_references() {
-            let b = self.graph.add_node(*aref.weight());
-            let i = mol.to_index(aref.id());
-            node_map[i] = b;
-            atom_map.push(i);
-            bits.set(b.index(), true);
-        }
-        for eref in mol.edge_references() {
-            let s = node_map[mol.to_index(eref.source())];
-            let t = node_map[mol.to_index(eref.target())];
-            debug_assert_ne!(s, end);
-            debug_assert_ne!(t, end);
-            self.graph.add_edge(s, t, *eref.weight());
-        }
-        let idx = self.push_frag((MolRepr::Atomic(bits), Ix::new(mol.node_count())));
-        info!(idx = idx.index(), "inserting atomic");
-        (idx, atom_map)
-    }
-
-    /// Insert a molecule into the arena, deduplicating common parts.
-    fn insert_mol_impl<G>(&mut self, mol: G, at: Option<usize>) -> (Ix, usize)
-    where
-        G: Data<NodeWeight = Atom, EdgeWeight = Bond>
-            + misc::DataValueMap
-            + GraphProp<EdgeType = Undirected>
-            + GetAdjacencyMatrix
-            + NodeCompactIndexable
-            + IntoEdgesDirected
-            + IntoNodeReferences,
-        G::NodeId: Hash + Eq,
-    {
         let max = <Ix as IndexType>::max().index();
-        if at.is_none() {
-            assert!(
-                mol.node_count() < max,
-                "molecule has too many atoms: {}, max is {max}",
-                mol.node_count()
-            );
-        }
+        assert!(
+            mol.node_count() < max,
+            "molecule has too many atoms: {}, max is {max}",
+            mol.node_count()
+        );
         let mut scratch = Vec::new();
         let mut frags = {
-            let (mut frags, mut src) = self
-                .parts
+            let (frags, mut src) = self.parts[isms_from..]
                 .iter()
                 .enumerate()
-                .filter_map(|(n, frag)| -> Option<(_, &[_])> {
-                    if at == Some(n) {
-                        return None;
-                    }
-                    match &frag.0 {
-                        MolRepr::Atomic(_) => Some((n, &[])),
-                        MolRepr::Broken(b) => Some((n, &b.frags)),
-                        // MolRepr::Modify(m) => Some((n, std::slice::from_ref(&m.base))),
-                        _ => None,
-                    }
+                .filter_map(|(n, frag)| {
+                    let children = match &frag.0 {
+                        MolRepr::Atomic(_) => &[] as &[_],
+                        MolRepr::Broken(b) => &b.frags,
+                        MolRepr::Modify(m) => std::slice::from_ref(&m.base),
+                    };
+                    (frag.1.index() <= mol.node_count()).then_some((n + isms_from, children))
                 })
                 .partition::<Vec<_>, _>(|v| v.1.is_empty());
+            let mut frags = VecDeque::from(frags);
             let mut edge = frags.iter().map(|i| i.0).collect::<Vec<_>>();
             frags.reserve(src.len());
             while !edge.is_empty() {
@@ -301,7 +202,7 @@ impl<Ix: IndexType> Arena<Ix> {
                         }
                     }
                     scratch.push(*i);
-                    frags.push((*i, *subs));
+                    frags.push_back((*i, *subs));
                     *i = usize::MAX;
                 }
                 std::mem::swap(&mut edge, &mut scratch);
@@ -316,288 +217,107 @@ impl<Ix: IndexType> Arena<Ix> {
             debug!(?frags, "topo-sorted fragments");
             frags
         };
-
-        let mut found = Vec::new();
-        let mut matched = vec![(usize::MAX, 0); mol.node_bound()];
-        let mut mods = SmallVec::<(Ix, Atom), 4>::with_capacity(mol.node_count());
-        let mut rbonds = ASmallMap::<MODDED_GRAPH_LEN, G::NodeId, Atom>::new();
-        let mut idx = 0;
-        let mut amatch = Atom::matches;
-        let mut bmatch = PartialEq::eq;
-
-        let mut search_stack = SmallVec::<_, 2>::new();
-        let mut preds_found = SmallVec::<_, 3>::new();
-        let mut push_list = SmallVec::<_, 8>::new();
-        let mut frag = None;
-        'main: while idx < frags.len() {
-            let (i, subs) = frags[idx];
-            let cmp = self.molecule(Ix::new(i));
+        let mut matched = vec![(IndexType::max(), usize::MAX); mol.node_count()];
+        let seen_buf = UnsafeCell::new(BSType::new());
+        let pred_buf = UnsafeCell::new(SmallVec::new());
+        let mut prune_buf = Vec::new();
+        let mut found = Slab::new();
+        while let Some((i, _)) = frags.pop_front() {
+            let i = Ix::new(i);
+            let matched = Cell::from_mut(&mut *matched).as_slice_of_cells();
+            let filtered = NodeFilter::new(mol, |n| {
+                let idx = mol.to_index(n);
+                if let Some(b) = &bits {
+                    if !b.get(idx) {
+                        return false;
+                    }
+                }
+                let v = matched[idx].get();
+                // SAFETY: the UnsafeCells' data doesn't escape the call
+                unsafe {
+                    v.0 == IndexType::max()
+                        || self.contains_group_impl(
+                            i,
+                            v.0,
+                            &mut *pred_buf.get(),
+                            &mut *seen_buf.get(),
+                        )
+                }
+            });
+            let compacted = GraphCompactor::<NodeFilter<G, _>>::new(filtered);
+            let frag = self.molecule(i);
+            let mut amatch = Atom::matches;
+            let mut bmatch = PartialEq::eq;
             let mut found_any = false;
-            preds_found.clear();
-
-            let mut it = isomorphisms_iter(&cmp, &mol, &mut amatch, &mut bmatch, true).peekable();
-            if it.peek().is_some() {
-                debug!(idx, "isomorphisms exist");
-            } else {
-                debug!(idx, "no isomorphisms found");
-            }
-            'isms: while let Some(ism) = it.next() {
-                if ism.len() == mol.node_count() {
-                    mods.clear();
-
-                    for (cmp_i, &mol_i) in ism.iter().enumerate() {
-                        let graph_atom = cmp.get_atom(Ix::new(cmp_i)).unwrap();
-                        let mol_atom = mol.node_weight(mol.from_index(mol_i)).unwrap();
-                        if graph_atom != mol_atom {
-                            let mi = Ix::new(mol_i);
-                            if let Err(idx) = mods.binary_search_by_key(&mi, |m| m.0) {
-                                mods.insert(idx, (mi, mol_atom));
-                            }
-                        }
-                    }
-
-                    // perfect match!
-                    if mods.is_empty() {
-                        info!(idx = i, "perfect isomorphism");
-                        debug_assert!(at.is_none(), "perfect isomorphism: {:?} == {:?}\n{self:#?}", Some(i), at);
-                        return (Ix::new(i), 0);
-                    }
-
-                    // not quite perfect, let's see if there's already another modded mol
-                    for (idx, frag) in self.parts.iter().enumerate() {
-                        if let MolRepr::Modify(m) = &frag.0 {
-                            if m.base.index() == i && m.patch == mods {
-                                info!(idx, base = i.index(), "matched isomorphism");
-                                return (Ix::new(idx), 0);
-                            }
-                        }
-                    }
-
-                    // no similar moddeds exist, this is the last ism
-                    if it.peek().is_none() {
-                        info!(idx = self.parts.len(), base = i, "created isomorphism");
-                        frag = Some((
-                            MolRepr::Modify(ModdedMol {
-                                base: Ix::new(i),
-                                patch: mods,
-                            }),
-                            Ix::new(mol.node_count()),
-                        ));
-                        break 'main;
-                    }
-                }
-                debug!(idx = i, ?ism, "found subgraph isomorphism");
+            for mut ism in isomorphisms_iter(&frag, &&compacted, &mut amatch, &mut bmatch, false) {
+                println!("found ism");
                 found_any = true;
-                push_list.clear();
-                for (cmp_i, &mol_i) in ism.iter().enumerate() {
-                    let graph_id = Ix::new(cmp_i).into();
-                    let mol_id = mol.from_index(mol_i);
-                    let graph_atom = cmp.get_atom(graph_id).unwrap();
-                    let mol_atom = mol.node_weight(mol_id).unwrap();
-                    trace!(graph_atom.protons, mol_atom.protons);
-
-                    // find the unmatched neighbors
-                    let mut neighbors = mol
-                        .edges(mol_id)
-                        .map(|e| {
-                            let i = if e.source() == mol_id {
-                                e.target()
-                            } else {
-                                e.source()
-                            };
-                            (*e.weight(), i)
-                        })
-                        .collect::<SmallVec<_, 4>>();
-                    cmp.neighbors(graph_id)
-                        .for_each(|n| neighbors.retain(|e| ism[n.0.index()] != mol.to_index(e.1)));
-
-                    if matched[mol_i].0 != usize::MAX {
-                        trace!(
-                            mol_i,
-                            frag = matched[mol_i].0,
-                            cmp_i = matched[mol_i].1,
-                            "atom already matched"
-                        );
-                        // search through subgraphs
-                        if preds_found.is_empty() && !subs.is_empty() {
-                            let _span =
-                                trace_span!("searching predecessors", frag = mol_i).entered();
-                            search_stack.clear();
-                            search_stack.extend_from_slice(subs);
-                            while let Some(pred) = search_stack.pop() {
-                                trace!(pred = pred.index(), "found predecessor");
-                                if !preds_found.contains(&pred) {
-                                    preds_found.push(pred);
-                                }
-                                match self.parts[pred.index()].0 {
-                                    MolRepr::Broken(ref b) => {
-                                        search_stack.extend_from_slice(&b.frags)
-                                    }
-                                    MolRepr::Atomic(_) => {}
-                                    MolRepr::Modify(ModdedMol { base, .. }) => {
-                                        search_stack.push(base)
-                                    }
-                                }
-                            }
-                            // sort it just for that lookup speed boost
-                            preds_found.sort_unstable();
-                        }
-                        // predecessor not found, this atom is already accounted for
-                        if preds_found.binary_search(&Ix::new(mol_i)).is_err() {
-                            trace!("predecessor not found");
-                            continue 'isms;
-                        }
-                    }
-                    let diff = mol_atom.data.single()
-                        - cmp
-                            .edges(graph_id)
-                            .filter(|e| *e.weight() == Bond::Single)
-                            .count() as u8;
-                    // assert!(
-                    //     neighbors.len() < 2,
-                    //     "too many neighbors: {}",
-                    //     neighbors.len()
-                    // );
-                    for (b, n) in neighbors {
-                        if b != Bond::Single {
-                            continue 'isms;
-                        }
-                        debug!(
-                            neighbor = mol.to_index(n),
-                            "adding an additional suppressed R-group"
-                        );
-                        if let Some(a) = rbonds.get_mut(&n) {
-                            a.data.set_single(a.data.single() - diff);
-                            a.data.set_unknown(a.data.unknown() + diff);
-                        } else {
-                            let mut a = mol.node_weight(n).unwrap();
-                            a.data.set_single(a.data.single() - 1);
-                            a.data.set_unknown(a.data.unknown() + 1);
-                            rbonds.insert(n, a);
-                        }
-                    }
-                    push_list.push((mol_i, i, cmp_i));
+                prune_buf.clear();
+                for to in &mut ism {
+                    let new = mol.to_index(compacted.node_map[*to]);
+                    *to = new;
+                    prune_buf.push(Ix::new(new));
                 }
-                for &(mol_i, i, cmp_i) in &push_list {
-                    matched[mol_i] = (i, cmp_i);
+                let idx = found.insert((i, ism));
+                for p in &prune_buf {
+                    let old_idx = matched[p.index()].replace((i, idx)).1;
+                    found.try_remove(old_idx);
                 }
-                found.push((i, ism));
             }
-            if found_any {
-                idx += 1;
-            } else {
-                let mut index = 0;
-                frags.retain(|(_, subs)| {
-                    let res = index < idx || (index != idx && !subs.contains(&Ix::new(i)));
-                    index += 1;
-                    res
+            if !found_any {
+                prune_buf.clear();
+                frags.retain(|&(n, p)| {
+                    prune_buf.iter().rev().any(|i| p.contains(i)) && {
+                        prune_buf.push(Ix::new(n));
+                        true
+                    }
                 });
-                if idx + 1 == frags.len() {
-                    break;
-                }
-            }
-        }
-        if let Some(frag) = frag {
-            if let Some(idx) = at {
-                let old = std::mem::replace(&mut self.parts[idx], frag);
-                if let MolRepr::Atomic(a) = old.0 {
-                    for i in 0..self.graph.node_count() {
-                        if a.get(i) {
-                            self.graph.remove_node(Ix::new(i).into());
-                        }
-                    }
-                }
-                return (Ix::new(idx), 0);
-            } else {
-                return (self.push_frag(frag), 0);
             }
         }
         if found.is_empty() {
-            if let Some(idx) = at {
-                return (Ix::new(idx), 0);
-            } else {
-                info!("no subgraphs found, delegating to atomic");
-                return (self.insert_mol_atomic(mol, false).0, 0);
+            let mut mapping = vec![(IndexType::max(), 0); mol.node_count()];
+            let mut count = 0;
+            for n in mol.node_references() {
+                let mi = mol.to_index(n.id());
+                if let Some(b) = &bits {
+                    if !b.get(mi) {
+                        continue;
+                    }
+                }
+                let gi = self.graph.add_node(*n.weight());
+                mapping[mi] = (gi, mi);
+                count += 1;
             }
-        }
-        let modded = ModdedGraph {
-            graph: mol,
-            mods: rbonds,
-        };
-        trace!(n_mods = modded.mods.len(), "tracked modifications");
-        let filtered = NodeFilter::new(&modded, |i| matched[modded.to_index(i)].0 == usize::MAX);
-        let ext_start = found.len();
-        found.extend(ConnectedGraphIter::new(&filtered).iter(mol).map(|bits| {
-            let graph = BitFiltered::<_, usize, ATOM_BIT_STORAGE, true>::new(&filtered, bits);
-            let (ix, map) = self.insert_mol_atomic(&graph, true);
-            let out = map.iter().map(|i| graph.filter.nth(*i).unwrap()).collect();
-            (ix.index(), out)
-        }));
-        debug!(count = found.len() - ext_start, "unmatched sections split");
-        found.sort_unstable();
-        // reassign all because we just invalidated our indices
-        for (i, ism) in &found[ext_start..] {
-            for (cmp_i, &mol_i) in ism.iter().enumerate() {
-                matched[mol_i] = (*i, cmp_i);
-            }
-        }
-        let mut frags = SmallVec::with_capacity(found.len());
-        let mut bonds = SmallVec::with_capacity(found.len() - 1);
-
-        for &(frag, ref ism) in &found {
-            frags.push(Ix::new(frag));
-
-            let cmp = self.molecule(Ix::new(frag));
-
-            for (cmp_i, &mol_i) in ism.iter().enumerate() {
-                let cmp_id = Ix::new(cmp_i).into();
-                let mol_id = mol.from_index(mol_i);
-                let cmp_atom = cmp.get_atom(cmp_id).unwrap();
-                let mol_atom = mol.node_weight(mol_id).unwrap();
-                let extra_rs = cmp_atom.data.unknown().saturating_sub(mol_atom.data.unknown());
-                if extra_rs == 0 {
+            for e in mol.edge_references() {
+                let a = mapping[mol.to_index(e.source())].0;
+                let b = mapping[mol.to_index(e.target())].0;
+                if a == IndexType::max() || b == IndexType::max() {
                     continue;
                 }
-                scratch.clear();
-                scratch.extend(mol.neighbors(mol_id).map(|n| mol.to_index(n)));
-                for n in cmp.neighbors(cmp_id).map(|n| n.0.index()) {
-                    let (bn, bi) = matched[n];
-                    // use ordering check to ensure only one bond is made
-                    if bn > frag {
-                        bonds.push(InterFragBond {
-                            an: Ix::new(frag),
-                            ai: Ix::new(cmp_i),
-                            bn: Ix::new(bn),
-                            bi: Ix::new(bi),
-                        });
-                    }
-                }
+                self.graph.add_edge(a, b, *e.weight());
+            }
+            mapping.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+            let (new_bits, new_map) = mapping.into_iter().map(|x| (x.0.index(), x.1)).unzip();
+            let idx = self.push_frag((MolRepr::Atomic(new_bits), Ix::new(count)));
+            return (idx, new_map);
+        } else if found.len() == 1 {
+            let (n, (_, ism)) = found.iter().next().unwrap();
+            if ism.len() == mol.node_count() {
+                return found.remove(n);
             }
         }
-
-        bonds.sort_unstable();
-
-        let out = (
-            MolRepr::Broken(BrokenMol { frags, bonds }),
-            Ix::new(mol.node_count()),
+        let old_start = self.parts.len();
+        let filtered = NodeFilter::new(mol, |n| matched[mol.to_index(n)].0 == IndexType::max());
+        let mut cgi = bits.as_ref().map_or_else(
+            || ConnectedGraphIter::new(&filtered),
+            |b| ConnectedGraphIter::from_full((**b).clone()),
         );
-        if let Some(idx) = at {
-            let old = std::mem::replace(&mut self.parts[idx], out);
-            if let MolRepr::Atomic(a) = old.0 {
-                for i in 0..self.graph.node_count() {
-                    if a.get(i) {
-                        self.graph.remove_node(Ix::new(i).into());
-                    }
-                }
-            }
-            (Ix::new(idx), mol.node_count())
-        } else {
-            let i = self.parts
-                .iter()
-                .position(|f| *f == out)
-                .map_or_else(|| self.push_frag(out), Ix::new);
-            (i, 0)
+        let mut default = BSType::new(); // no alloc
+        let bits = bits.unwrap_or(&mut default);
+        while cgi.step(&filtered, bits) {
+            found.insert(self.insert_mol_impl(mol, old_start, Some(bits)));
         }
+        todo!()
     }
     #[inline(always)]
     #[instrument(skip(self, mol), fields(size = mol.node_count()))]
@@ -612,6 +332,6 @@ impl<Ix: IndexType> Arena<Ix> {
             + IntoNodeReferences,
         G::NodeId: Hash + Eq,
     {
-        self.insert_mol_impl(mol, None).0
+        self.insert_mol_impl(mol, 0, None).0
     }
 }

--- a/src/arena/arena.rs
+++ b/src/arena/arena.rs
@@ -278,7 +278,7 @@ impl<Ix: IndexType> Arena<Ix> {
             let mut bmatch = PartialEq::eq;
             let mut found_any = false;
             'isms: for mut ism in
-                isomorphisms_iter(&frag, &&compacted, &mut amatch, &mut bmatch, false)
+                isomorphisms_iter(&frag, &&compacted, &mut amatch, &mut bmatch, true)
             {
                 trace!(frag = i.index(), ?ism, "found fragment");
                 prune_buf.clear();

--- a/src/arena/arena.rs
+++ b/src/arena/arena.rs
@@ -88,6 +88,11 @@ impl<Ix: IndexType> Arena<Ix> {
     pub fn expose_parts(&self) -> &(impl Debug + Clone + PartialEq) {
         &self.parts
     }
+    /// Get a reference to a single fragment. For debugging purposes only.
+    #[inline(always)]
+    pub fn expose_part(&self, index: usize) -> &(impl Debug + Clone + PartialEq) {
+        &self.parts[index]
+    }
 
     #[inline]
     fn push_frag(&mut self, frag: (MolRepr<Ix>, Ix)) -> Ix {

--- a/src/arena/molecule/graph_traits.rs
+++ b/src/arena/molecule/graph_traits.rs
@@ -107,21 +107,26 @@ impl<Ix: IndexType + Ord, R: ArenaAccessor<Ix = Ix> + Copy> GetAdjacencyMatrix f
     fn adjacency_matrix(&self) -> Self::AdjMatrix {
         let mut out = Self::AdjMatrix::new();
         for e in self.edge_references() {
-            let s = e.source().0.index();
-            let t = e.target().0.index();
-            let i = if t == 0 { 0 } else { t * (t - 1) / 2 } + s;
+            let a = e.source().0.index();
+            let b = e.target().0.index();
+            if a == b {
+                continue;
+            }
+            let (s, t) = if a < b { (a, b) } else { (b, a) };
+            let i = t * (t - 1) / 2 + s;
             out.set(i, true);
         }
         out
     }
-    #[rustfmt::skip]
-    fn is_adjacent(&self, _matrix: &Self::AdjMatrix, a: Self::NodeId, b: Self::NodeId) -> bool {
-        return self.get_bond([a, b]).is_some(); // TODO: fix this implementation
-        // let a = a.0.index();
-        // let b = b.0.index();
-        // let (s, t) = if a < b { (a, b) } else { (b, a) };
-        // let i = if t == 0 { 0 } else { t * (t - 1) / 2 } + s;
-        // matrix.get(i)
+    fn is_adjacent(&self, matrix: &Self::AdjMatrix, a: Self::NodeId, b: Self::NodeId) -> bool {
+        if a == b {
+            return false;
+        }
+        let a = a.0.index();
+        let b = b.0.index();
+        let (s, t) = if a < b { (a, b) } else { (b, a) };
+        let i = t * (t - 1) / 2 + s;
+        matrix.get(i)
     }
 }
 impl<Ix: IndexType + Ord, R> Visitable for Molecule<Ix, R> {

--- a/src/arena/molecule/graph_traits.rs
+++ b/src/arena/molecule/graph_traits.rs
@@ -347,7 +347,8 @@ pub mod iter {
                             }
                             self.state = State::Uninit;
                         } else {
-                            let offsets = b.frags
+                            let offsets = b
+                                .frags
                                 .iter()
                                 .scan(self.offset.index(), |count, idx| {
                                     let old = *count;

--- a/src/arena/molecule/graph_traits.rs
+++ b/src/arena/molecule/graph_traits.rs
@@ -114,12 +114,13 @@ impl<Ix: IndexType + Ord, R: ArenaAccessor<Ix = Ix> + Copy> GetAdjacencyMatrix f
         }
         out
     }
-    fn is_adjacent(&self, matrix: &Self::AdjMatrix, a: Self::NodeId, b: Self::NodeId) -> bool {
-        let a = a.0.index();
-        let b = b.0.index();
-        let (s, t) = if a < b { (a, b) } else { (b, a) };
-        let i = if t == 0 { 0 } else { t * (t - 1) / 2 } + s;
-        matrix.get(i)
+    fn is_adjacent(&self, _matrix: &Self::AdjMatrix, a: Self::NodeId, b: Self::NodeId) -> bool {
+        return self.get_bond([a, b]).is_some(); // TODO: fix this implementation
+        // let a = a.0.index();
+        // let b = b.0.index();
+        // let (s, t) = if a < b { (a, b) } else { (b, a) };
+        // let i = if t == 0 { 0 } else { t * (t - 1) / 2 } + s;
+        // matrix.get(i)
     }
 }
 impl<Ix: IndexType + Ord, R> Visitable for Molecule<Ix, R> {

--- a/src/arena/molecule/graph_traits.rs
+++ b/src/arena/molecule/graph_traits.rs
@@ -201,10 +201,8 @@ pub mod iter {
                             .collect::<SmallVec<_, 3>>();
                         let mut it = bonds.iter().map(|b| {
                             EdgeReference::with_weight(
-                                EdgeIndex::new(
-                                    Ix::new(offsets[b.an.index()] + b.ai.index()),
-                                    Ix::new(offsets[b.bn.index()] + b.bi.index()),
-                                ),
+                                Ix::new(offsets[b.an.index()] + b.ai.index()),
+                                Ix::new(offsets[b.bn.index()] + b.bi.index()),
                                 Bond::Single,
                             )
                         });
@@ -219,7 +217,8 @@ pub mod iter {
                             let s = b.index(e.source().index())?;
                             let t = b.index(e.target().index())?;
                             Some(EdgeReference::with_weight(
-                                (Ix::new(s + offset), Ix::new(t + offset)).into(),
+                                Ix::new(s + offset),
+                                Ix::new(t + offset),
                                 *e.weight(),
                             ))
                         });
@@ -309,7 +308,8 @@ pub mod iter {
                             // get the correct offset index
                             let offset = idx + self.offset.index();
                             return Some(EdgeReference::with_weight(
-                                EdgeIndex::new(self.orig_idx, Ix::new(offset)),
+                                self.orig_idx,
+                                Ix::new(offset),
                                 arena.graph()[e],
                             ));
                         }
@@ -319,7 +319,8 @@ pub mod iter {
                         if let State::Broken(next) = &mut self.state {
                             if let Some(id) = next.pop() {
                                 return Some(EdgeReference::with_weight(
-                                    EdgeIndex::new(self.orig_idx, id),
+                                    self.orig_idx,
+                                    id,
                                     Bond::Single,
                                 ));
                             }
@@ -382,13 +383,7 @@ pub mod iter {
         type Item = NodeIndex<Ix>;
 
         fn next(&mut self) -> Option<Self::Item> {
-            self.0.next().map(|n| {
-                if n.source().0 == self.0.atom_idx {
-                    n.target()
-                } else {
-                    n.source()
-                }
-            })
+            self.0.next().map(|n| n.target())
         }
     }
 

--- a/src/arena/molecule/mod.rs
+++ b/src/arena/molecule/mod.rs
@@ -1,5 +1,6 @@
 use super::arena::*;
 use super::*;
+use petgraph::visit::IntoNodeReferences;
 use small_map::ASmallMap;
 
 pub mod graph_traits;
@@ -253,6 +254,21 @@ impl<Ix: IndexType, R: ArenaAccessor<Ix = Ix>> Molecule<Ix, R> {
 
     pub fn contained_groups(&self) -> ContainedGroups<Ix, R> {
         ContainedGroups::new(self.index, self.arena)
+    }
+    pub fn graph_elements(
+        &self,
+    ) -> impl Iterator<Item = petgraph::data::Element<Atom, Bond>> + Clone {
+        use petgraph::data::Element;
+        use petgraph::visit::*;
+        self.node_references()
+            .map(|i| Element::Node {
+                weight: *i.weight(),
+            })
+            .chain(self.edge_references().map(|e| Element::Edge {
+                source: e.source().0.index(),
+                target: e.target().0.index(),
+                weight: *e.weight(),
+            }))
     }
 }
 

--- a/src/arena/molecule/mod.rs
+++ b/src/arena/molecule/mod.rs
@@ -285,7 +285,7 @@ impl<Ix, R> ContainedGroups<Ix, R> {
     pub fn new(group: Ix, arena: R) -> Self {
         Self {
             stack: vec![group],
-            arena
+            arena,
         }
     }
 }

--- a/src/arena/molecule/mod.rs
+++ b/src/arena/molecule/mod.rs
@@ -161,10 +161,14 @@ impl<Ix: IndexType, R: ArenaAccessor<Ix = Ix>> Molecule<Ix, R> {
                         }
                     }
                     let n = found?;
-                    cvt_singles += b.bonds.iter().filter(|ifb| {
-                        (ifb.an.index() == n && ifb.ai.index() == idx) ||
-                        (ifb.bn.index() == n && ifb.bi.index() == idx)
-                    }).count() as u8;
+                    cvt_singles += b
+                        .bonds
+                        .iter()
+                        .filter(|ifb| {
+                            (ifb.an.index() == n && ifb.ai.index() == idx)
+                                || (ifb.bn.index() == n && ifb.bi.index() == idx)
+                        })
+                        .count() as u8;
                 }
             }
         }

--- a/src/arena/molecule/mod.rs
+++ b/src/arena/molecule/mod.rs
@@ -128,7 +128,6 @@ impl<Ix: IndexType, R: ArenaAccessor<Ix = Ix>> Molecule<Ix, R> {
         let mut idx = idx.0.index();
         let arena = self.arena.get_arena();
         (idx < arena.parts.get(self.index.index())?.1.index()).then_some(())?;
-
         let mut ix = self.index;
         loop {
             trace!(mol_idx = ix.index(), atom_idx = idx, "searching for atom");
@@ -148,7 +147,7 @@ impl<Ix: IndexType, R: ArenaAccessor<Ix = Ix>> Molecule<Ix, R> {
                     let mut found = false;
                     for p in &b.frags {
                         let s = arena.parts[p.index()].1.index();
-                        if idx > s {
+                        if idx >= s {
                             idx -= s;
                         } else {
                             ix = *p;

--- a/src/arena/molecule/node_impls.rs
+++ b/src/arena/molecule/node_impls.rs
@@ -133,7 +133,7 @@ impl<Ix: PartialOrd> EdgeReference<Ix> {
                 .get_bond(edge_idx)
                 .unwrap(),
             target_first: target < source,
-            edge_idx
+            edge_idx,
         }
     }
     pub fn with_weight(source: Ix, target: Ix, weight: Bond) -> Self {

--- a/src/arena/molecule/node_impls.rs
+++ b/src/arena/molecule/node_impls.rs
@@ -116,7 +116,6 @@ impl<Ix> NodeReference<Ix> {
     where
         Ix: IndexType,
     {
-        println!("mi: {}, ni: {}", mol_idx.index(), node_idx.0.index());
         Self {
             node_idx,
             atom: arena

--- a/src/bin/repl.rs
+++ b/src/bin/repl.rs
@@ -64,6 +64,7 @@ enum QueryType {
     AllEdges,
     Neighbors,
     NeighborEdges,
+    Contained,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -524,6 +525,14 @@ fn query(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplErro
                     }
                 }
                 Ok(Some(out))
+            }
+            QueryType::Contained => {
+                if focus.is_some() {
+                    Err(ReplError::FocusNodesOnQuery)
+                } else {
+                    let set = mol.contained_groups().collect::<std::collections::HashSet<_>>();
+                    Ok(Some(format!("{set:?}")))
+                }
             }
         }
     })

--- a/src/bin/repl.rs
+++ b/src/bin/repl.rs
@@ -22,6 +22,8 @@ enum DumpType {
     FastSmiles,
     #[value(alias = "smiles")]
     CanonSmiles,
+    #[value(alias = "frags", alias = "fragment")]
+    Frag,
     #[cfg(feature = "coordgen")]
     Svg,
     #[cfg(all(feature = "coordgen", feature = "resvg"))]
@@ -290,6 +292,20 @@ fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError
                 } else {
                     Ok(Some(s))
                 }
+            }
+            DumpType::Frag => {
+                let mut out = String::new();
+                if let Some(inputs) = args.get_many::<u32>("mol") {
+                    for i in inputs {
+                        if !out.is_empty() {
+                            out.push('\n');
+                        }
+                        let _ = write!(out, "{:#?}", ctx.arena.expose_part(*i as _));
+                    }
+                } else {
+                    let _ = write!(out, "{:#?}", ctx.arena.expose_parts());
+                }
+                Ok(Some(out))
             }
             #[cfg(feature = "coordgen")]
             DumpType::Svg => {

--- a/src/core.rs
+++ b/src/core.rs
@@ -124,7 +124,11 @@ impl AtomData {
 }
 impl PartialEq for AtomData {
     fn eq(&self, other: &Self) -> bool {
-        self.chirality() == other.chirality() && self.hydrogen() == other.hydrogen() && self.unknown() == other.unknown() && self.single() == other.single() && self.other() == other.other()
+        self.chirality() == other.chirality()
+            && self.hydrogen() == other.hydrogen()
+            && self.unknown() == other.unknown()
+            && self.single() == other.single()
+            && self.other() == other.other()
     }
 }
 impl Eq for AtomData {}
@@ -214,6 +218,20 @@ impl Atom {
         } else {
             Err(TooManyBonds(TooMany::Other, b as _))
         }
+    }
+    /// Remove single bonds, replace them with unknowns
+    pub fn single_to_unknown(&mut self, b: u8) -> Result<(), TooManyBonds> {
+        let s = self.data.single();
+        if b > s {
+            return Err(TooManyBonds(TooMany::Single, 0));
+        }
+        let u = self.data.unknown() + b;
+        if u >= 16 {
+            return Err(TooManyBonds(TooMany::R, u as _));
+        }
+        self.data.set_single(s - b);
+        self.data.set_unknown(u);
+        Ok(())
     }
 
     #[inline(always)]

--- a/src/core.rs
+++ b/src/core.rs
@@ -233,6 +233,20 @@ impl Atom {
         self.data.set_unknown(u);
         Ok(())
     }
+    /// Remove unknown bonds, replace them with singles
+    pub fn unknown_to_single(&mut self, b: u8) -> Result<(), TooManyBonds> {
+        let u = self.data.unknown();
+        if b > u {
+            return Err(TooManyBonds(TooMany::R, 0));
+        }
+        let s = self.data.single() + b;
+        if s >= 16 {
+            return Err(TooManyBonds(TooMany::Single, s as _));
+        }
+        self.data.set_single(s);
+        self.data.set_unknown(u - b);
+        Ok(())
+    }
 
     #[inline(always)]
     pub fn map_scratch<F: FnOnce(u8) -> u8>(&mut self, f: F) {

--- a/src/core.rs
+++ b/src/core.rs
@@ -124,13 +124,17 @@ impl AtomData {
 }
 impl PartialEq for AtomData {
     fn eq(&self, other: &Self) -> bool {
-        self.chirality() == other.chirality() && self.is_compatible(*other)
+        self.chirality() == other.chirality() && self.hydrogen() == other.hydrogen() && self.unknown() == other.unknown() && self.single() == other.single() && self.other() == other.other()
     }
 }
 impl Eq for AtomData {}
 impl Hash for AtomData {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write_u8(self.total_bonds());
+        state.write_u8(self.chirality() as u8);
+        state.write_u8(self.hydrogen());
+        state.write_u8(self.unknown());
+        state.write_u8(self.single());
+        state.write_u8(self.other());
     }
 }
 

--- a/src/graph/algo/connect.rs
+++ b/src/graph/algo/connect.rs
@@ -3,7 +3,6 @@ use num_traits::PrimInt;
 use petgraph::visit::*;
 use smallvec::{smallvec, SmallVec};
 use std::fmt::{self, Binary, Debug, Formatter};
-use tracing::*;
 
 /// Iterate over connected graphs in a graph, returning their bits.
 #[derive(Clone)]
@@ -48,11 +47,29 @@ impl<T: PrimInt, const N: usize, F: FnMut(usize) -> usize> ConnectedGraphIter<T,
         }
         Self { full, cvt }
     }
+    pub fn step<G: IntoNeighbors + NodeIndexable, U: PrimInt, const O: usize>(&mut self, graph: G, out: &mut BitSet<U, O>) -> bool {
+        let start = self.full.nth(0);
+        let Some(start) = start else { return false };
+        let start = graph.from_index(start);
+        out.clear();
+        let mut stack: SmallVec<G::NodeId, 8> = smallvec![start];
+        while let Some(id) = stack.pop() {
+            let idx = graph.to_index(id);
+            self.full.set(idx, false);
+            let cvt = (self.cvt)(idx);
+            out.set(cvt, true);
+            stack.extend(graph.neighbors(id).filter(|&id| {
+                let idx = graph.to_index(id);
+                self.full.get(idx)
+            }))
+        }
+        true
+    }
 }
 
 impl<T: Binary, const N: usize, F> Debug for ConnectedGraphIter<T, N, F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DisjointGraphIter")
+        f.debug_struct("ConnectedGraphIter")
             .field("full", &self.full)
             .finish()
     }
@@ -60,32 +77,27 @@ impl<T: Binary, const N: usize, F> Debug for ConnectedGraphIter<T, N, F> {
 
 impl<
         G: IntoNeighbors + NodeIndexable,
-        T: PrimInt + Binary,
+        T: PrimInt,
         const N: usize,
         F: FnMut(usize) -> usize,
     > Walker<G> for ConnectedGraphIter<T, N, F>
 {
     type Item = BitSet<T, N>;
-    #[instrument(name = "connected_next", level = "debug", skip_all, fields(bits = ?self.full))]
     fn walk_next(&mut self, graph: G) -> Option<BitSet<T, N>> {
         let start = self.full.nth(0);
-        trace!(start, "starting node");
         let start = graph.from_index(start?);
         let mut stack: SmallVec<G::NodeId, 8> = smallvec![start];
         let mut out = BitSet::new();
         while let Some(id) = stack.pop() {
             let idx = graph.to_index(id);
             self.full.set(idx, false);
-            trace!(idx, "visited node");
             let cvt = (self.cvt)(idx);
-            trace!(cvt, "set bit");
             out.set(cvt, true);
             stack.extend(graph.neighbors(id).filter(|&id| {
                 let idx = graph.to_index(id);
                 self.full.get(idx)
             }))
         }
-        debug!(count = out.count_ones(), "returned");
         Some(out)
     }
 }

--- a/src/graph/algo/connect.rs
+++ b/src/graph/algo/connect.rs
@@ -35,7 +35,7 @@ impl<T: PrimInt, const N: usize> ConnectedGraphIter<T, N, fn(usize) -> usize> {
         }
     }
 }
-impl<T: PrimInt + std::fmt::Binary, const N: usize, F: FnMut(usize) -> usize> ConnectedGraphIter<T, N, F> {
+impl<T: PrimInt, const N: usize, F: FnMut(usize) -> usize> ConnectedGraphIter<T, N, F> {
     pub fn with_cvt<G: IntoNodeIdentifiers + NodeIndexable>(graph: G, cvt: F) -> Self {
         let mut full = BitSet::new();
         let mut max = 0;
@@ -48,7 +48,11 @@ impl<T: PrimInt + std::fmt::Binary, const N: usize, F: FnMut(usize) -> usize> Co
         }
         Self { full, cvt }
     }
-    pub fn step<G: IntoNeighbors + NodeIndexable, U: PrimInt, const O: usize>(&mut self, graph: G, out: &mut BitSet<U, O>) -> Option<NonZeroUsize> {
+    pub fn step<G: IntoNeighbors + NodeIndexable, U: PrimInt, const O: usize>(
+        &mut self,
+        graph: G,
+        out: &mut BitSet<U, O>,
+    ) -> Option<NonZeroUsize> {
         let start = self.full.nth(0);
         let Some(start) = start else { return None };
         let start = graph.from_index(start);
@@ -78,12 +82,8 @@ impl<T: Binary, const N: usize, F> Debug for ConnectedGraphIter<T, N, F> {
     }
 }
 
-impl<
-        G: IntoNeighbors + NodeIndexable,
-        T: PrimInt,
-        const N: usize,
-        F: FnMut(usize) -> usize,
-    > Walker<G> for ConnectedGraphIter<T, N, F>
+impl<G: IntoNeighbors + NodeIndexable, T: PrimInt, const N: usize, F: FnMut(usize) -> usize>
+    Walker<G> for ConnectedGraphIter<T, N, F>
 {
     type Item = BitSet<T, N>;
     fn walk_next(&mut self, graph: G) -> Option<BitSet<T, N>> {

--- a/src/tests/arena/insert.rs
+++ b/src/tests/arena/insert.rs
@@ -1,8 +1,10 @@
 use super::*;
 
+mod order;
+
 #[test]
 fn double_insert() {
-    super::trace_capture!();
+    trace_capture!();
     let mut arena = Arena::<u32>::new();
     let benzene = smiles!("c1ccccc1");
     let m1 = arena.insert_mol(&benzene);
@@ -49,7 +51,7 @@ fn isomorphism() {
 
 #[test]
 fn alcohols() {
-    super::trace_capture!();
+    trace_capture!();
     let mut arena = arena!(
         of u32:
         smiles!("O&"),     // alcohol

--- a/src/tests/arena/insert.rs
+++ b/src/tests/arena/insert.rs
@@ -79,3 +79,13 @@ fn alcohols() {
 
     assert!(isp.contains(alcohol));
 }
+
+/// Idfk what this test case is showing but it fails
+#[test]
+fn cursed_hydrazine() {
+    trace_capture!();
+    let mut arena = Arena::<u32>::new();
+    let hydrazine = arena.insert_mol(&smiles!("N&N&"));
+    let dimethylhydrazine = arena.insert_mol(&smiles!("CNNC"));
+    assert!(arena.contains_group(dimethylhydrazine, hydrazine));
+}

--- a/src/tests/arena/insert.rs
+++ b/src/tests/arena/insert.rs
@@ -58,15 +58,20 @@ fn alcohols() {
         smiles!("CCO"),    // ethanol
         smiles!("CC(C)O"), // isopropanol
     );
+    tracing::info!("arena created");
     let orig = arena.parts.clone();
 
     let alcohol = arena.insert_mol(&smiles!("O&"));
+    tracing::info!("alcohol inserted");
     assert_eq!(alcohol, 0);
     assert_eq!(orig.len(), arena.parts.len(), "arena length changed");
     assert!(orig == arena.parts, "arena changed");
 
     let isp_idx = arena.insert_mol(&smiles!("CC(C)O"));
+    tracing::info!("isopropanol inserted");
     let isp = arena.molecule(isp_idx);
+
+    println!("{:#?}", arena.parts);
 
     // if these aren't equal, the output is just ugly
     assert_eq!(orig.len(), arena.parts.len(), "arena length changed");

--- a/src/tests/arena/insert.rs
+++ b/src/tests/arena/insert.rs
@@ -83,9 +83,45 @@ fn alcohols() {
 /// Idfk what this test case is showing but it fails
 #[test]
 fn cursed_hydrazine() {
+    use crate::graph::isomorphisms_iter;
     trace_capture!();
+    let base_hz = smiles!("N&N&");
+    let base_dmhz = smiles!("CNNC");
+    assert_ne!(
+        isomorphisms_iter(
+            &&base_hz,
+            &&base_dmhz,
+            &mut Atom::matches,
+            &mut PartialEq::eq,
+            true
+        )
+        .next(),
+        None
+    );
     let mut arena = Arena::<u32>::new();
-    let hydrazine = arena.insert_mol(&smiles!("N&N&"));
-    let dimethylhydrazine = arena.insert_mol(&smiles!("CNNC"));
+    let hydrazine = arena.insert_mol(&base_hz);
+    let dimethylhydrazine = arena.insert_mol(&base_dmhz);
+    assert_ne!(
+        isomorphisms_iter(
+            &arena.molecule(hydrazine),
+            &&base_dmhz,
+            &mut Atom::matches,
+            &mut PartialEq::eq,
+            true
+        )
+        .next(),
+        None
+    );
+    assert_ne!(
+        isomorphisms_iter(
+            &arena.molecule(hydrazine),
+            &arena.molecule(dimethylhydrazine),
+            &mut Atom::matches,
+            &mut PartialEq::eq,
+            true
+        )
+        .next(),
+        None
+    );
     assert!(arena.contains_group(dimethylhydrazine, hydrazine));
 }

--- a/src/tests/arena/insert/order.rs
+++ b/src/tests/arena/insert/order.rs
@@ -1,0 +1,109 @@
+//! Tests for the arena insert order
+
+use super::*;
+
+#[test]
+fn small_large() {
+    let mut arena = Arena::<u8>::new();
+    let ether = arena.insert_mol(&smiles!("O&&"));
+    let dimethyl_ether = arena.insert_mol(&smiles!("COC"));
+    assert!(arena.contains_group(dimethyl_ether, ether));
+}
+
+#[test]
+fn large_small() {
+    let mut arena = Arena::<u8>::new();
+    let dimethyl_ether = arena.insert_mol(&smiles!("COC"));
+    let ether = arena.insert_mol(&smiles!("O&&"));
+    assert!(arena.contains_group(dimethyl_ether, ether));
+}
+
+#[test]
+fn small_med_large() {
+    // trace_capture!();
+    let mut arena = Arena::<u8>::new();
+    let ether = arena.insert_mol(&smiles!("O&&"));
+    let ketone = arena.insert_mol(&smiles!("C&&=O"));
+    let ester = arena.insert_mol(&smiles!("C&(=O)O&"));
+    let methyl_acetate = arena.insert_mol(&smiles!("CC(=O)OC"));
+
+    println!("{:#?}", arena.expose_parts());
+
+    assert!(arena.contains_group(ester, ether));
+    assert!(arena.contains_group(ester, ketone));
+    assert!(arena.contains_group(methyl_acetate, ether));
+    assert!(arena.contains_group(methyl_acetate, ketone));
+    assert!(arena.contains_group(methyl_acetate, ester));
+}
+
+#[test]
+fn small_large_med() {
+    // trace_capture!();
+    let mut arena = Arena::<u8>::new();
+    let ether = arena.insert_mol(&smiles!("O&&"));
+    let methyl_acetate = arena.insert_mol(&smiles!("CC(=O)OC"));
+    let ketone = arena.insert_mol(&smiles!("C&&=O"));
+    let ester = arena.insert_mol(&smiles!("C&(=O)O&"));
+
+    println!("{:#?}", arena.expose_parts());
+
+    assert!(arena.contains_group(ester, ether));
+    assert!(arena.contains_group(ester, ketone));
+    assert!(arena.contains_group(methyl_acetate, ether));
+    assert!(arena.contains_group(methyl_acetate, ketone));
+    assert!(arena.contains_group(methyl_acetate, ester));
+}
+
+#[test]
+fn large_med_small() {
+    // trace_capture!();
+    let mut arena = Arena::<u8>::new();
+    let methyl_acetate = arena.insert_mol(&smiles!("CC(=O)OC"));
+    let ester = arena.insert_mol(&smiles!("C&(=O)O&"));
+    let ether = arena.insert_mol(&smiles!("O&&"));
+    let ketone = arena.insert_mol(&smiles!("C&&=O"));
+
+    println!("{:#?}", arena.expose_parts());
+
+    assert!(arena.contains_group(ester, ether));
+    assert!(arena.contains_group(ester, ketone));
+    assert!(arena.contains_group(methyl_acetate, ether));
+    assert!(arena.contains_group(methyl_acetate, ketone));
+    assert!(arena.contains_group(methyl_acetate, ester));
+}
+
+#[test]
+fn large_small_med() {
+    // trace_capture!();
+    let mut arena = Arena::<u8>::new();
+    let methyl_acetate = arena.insert_mol(&smiles!("CC(=O)OC"));
+    let ether = arena.insert_mol(&smiles!("O&&"));
+    let ketone = arena.insert_mol(&smiles!("C&&=O"));
+    let ester = arena.insert_mol(&smiles!("C&(=O)O&"));
+
+    println!("{arena:#?}");
+
+    assert!(arena.contains_group(ester, ether));
+    assert!(arena.contains_group(ester, ketone));
+    assert!(arena.contains_group(methyl_acetate, ether));
+    assert!(arena.contains_group(methyl_acetate, ketone));
+    assert!(arena.contains_group(methyl_acetate, ester));
+}
+
+#[test]
+fn large_small_med_small() {
+    // trace_capture!();
+    let mut arena = Arena::<u8>::new();
+    let methyl_acetate = arena.insert_mol(&smiles!("CC(=O)OC"));
+    let ether = arena.insert_mol(&smiles!("O&&"));
+    let ester = arena.insert_mol(&smiles!("C&(=O)O&"));
+    let ketone = arena.insert_mol(&smiles!("C&&=O"));
+
+    println!("{:#?}", arena.expose_parts());
+
+    assert!(arena.contains_group(ester, ether));
+    assert!(arena.contains_group(ester, ketone));
+    assert!(arena.contains_group(methyl_acetate, ether));
+    assert!(arena.contains_group(methyl_acetate, ketone));
+    assert!(arena.contains_group(methyl_acetate, ester));
+}

--- a/src/tests/macros.rs
+++ b/src/tests/macros.rs
@@ -4,6 +4,7 @@ macro_rules! trace_capture {
         use tracing_subscriber::prelude::*;
 
         let targets = Targets::new()
+            .with_target("lute::tests", LevelFilter::TRACE)
             .with_target("lute::parse", LevelFilter::INFO)
             .with_target("lute::arena::molecule", LevelFilter::DEBUG)
             .with_target("lute::arena::arena", LevelFilter::TRACE);

--- a/src/utils/bitset.rs
+++ b/src/utils/bitset.rs
@@ -177,6 +177,21 @@ impl<T: Binary, const N: usize> Debug for BitSet<T, N> {
     }
 }
 
+impl<T: PrimInt, const N: usize> Extend<usize> for BitSet<T, N> {
+    fn extend<I: IntoIterator<Item = usize>>(&mut self, iter: I) {
+        for i in iter {
+            self.set(i, true);
+        }
+    }
+}
+impl<T: PrimInt + Default, const N: usize> FromIterator<usize> for BitSet<T, N> {
+    fn from_iter<I: IntoIterator<Item = usize>>(iter: I) -> Self {
+        let mut this = Self::default();
+        this.extend(iter);
+        this
+    }
+}
+
 impl<Ix: IndexType, T: PrimInt, const N: usize> VisitMap<NodeIndex<Ix>> for BitSet<T, N> {
     fn visit(&mut self, a: NodeIndex<Ix>) -> bool {
         self.set(a.0.index(), true)


### PR DESCRIPTION
The `Arena::insert` method was horribly buggy and barely gave an output that looked even remotely right. While the original purpose of this branch was to rewrite it so that it could handle any insertion order, this PR leaves things with the same behavior as what was documented before but... actually working.

Also, some tests are failing now. They would've failed before, anyways :3