### PR TITLE
Fix some bugs, add a layout optimization

### DIFF
--- a/src/arena/arena.rs
+++ b/src/arena/arena.rs
@@ -600,7 +600,6 @@ impl<Ix: IndexType> Arena<Ix> {
                 prune_buf.clear();
                 scratch.retain(|(n, c)| {
                     !c.is_empty() || {
-                        println!("{slice:?}[{i}]");
                         slice[i] = (*n, 0);
                         i += 1;
                         prune_buf.push(*n);

--- a/src/arena/arena.rs
+++ b/src/arena/arena.rs
@@ -268,13 +268,7 @@ impl<Ix: IndexType> Arena<Ix> {
                 let v = matched[idx].get();
                 // SAFETY: the UnsafeCells' data doesn't escape the call
                 unsafe {
-                    v.0 == IndexType::max()
-                        || self.contains_group_impl(
-                            i,
-                            v.0,
-                            &mut *pred_buf.get(),
-                            &mut *seen_buf.get(),
-                        )
+                    self.contains_group_impl(i, v.0, &mut *pred_buf.get(), &mut *seen_buf.get())
                 }
             });
             let compacted = GraphCompactor::<NodeFilter<G, _>>::new(filtered);

--- a/src/arena/arena.rs
+++ b/src/arena/arena.rs
@@ -269,12 +269,13 @@ impl<Ix: IndexType> Arena<Ix> {
                 // SAFETY: the UnsafeCells' data doesn't escape the call
                 unsafe {
                     v.0 == IndexType::max()
-                        || self.contains_group_impl(
-                            i,
-                            v.0,
-                            &mut *pred_buf.get(),
-                            &mut *seen_buf.get(),
-                        )
+                        || (i != v.0
+                            && self.contains_group_impl(
+                                i,
+                                v.0,
+                                &mut *pred_buf.get(),
+                                &mut *seen_buf.get(),
+                            ))
                 }
             });
             let compacted = GraphCompactor::<NodeFilter<G, _>>::new(filtered);

--- a/src/arena/arena.rs
+++ b/src/arena/arena.rs
@@ -268,7 +268,13 @@ impl<Ix: IndexType> Arena<Ix> {
                 let v = matched[idx].get();
                 // SAFETY: the UnsafeCells' data doesn't escape the call
                 unsafe {
-                    self.contains_group_impl(i, v.0, &mut *pred_buf.get(), &mut *seen_buf.get())
+                    v.0 == IndexType::max()
+                        || self.contains_group_impl(
+                            i,
+                            v.0,
+                            &mut *pred_buf.get(),
+                            &mut *seen_buf.get(),
+                        )
                 }
             });
             let compacted = GraphCompactor::<NodeFilter<G, _>>::new(filtered);

--- a/src/bin/repl.rs
+++ b/src/bin/repl.rs
@@ -694,6 +694,16 @@ fn main() {
             load_smiles,
         )
         .with_command(
+            Command::new("optimize").about("Optimize arena layout"),
+            |_, ctx| {
+                catch_panics(|| {
+                    let mut out = Vec::new();
+                    ctx.arena.optimize_layout(Some(&mut out));
+                    Ok(Some(format!("{out:?}")))
+                })
+            },
+        )
+        .with_command(
             Command::new("dump")
                 .about("Show the output of inputs, or the whole graph if no ids are given")
                 .arg(

--- a/src/core.rs
+++ b/src/core.rs
@@ -121,6 +121,29 @@ impl AtomData {
         debug_assert_eq!(u1, u2, "u1 == u2 should hold because their sums are equal!");
         true
     }
+
+    pub fn compatible_one_way(self, other: Self) -> bool {
+        let Some(mut u) = self.unknown().checked_sub(other.unknown()) else {
+            return false;
+        };
+        let Some(h) = other.hydrogen().checked_sub(self.hydrogen()) else {
+            return false;
+        };
+        let Some(o) = other.single().checked_sub(self.single()) else {
+            return false;
+        };
+        if h >= u {
+            u -= h;
+        } else {
+            return false;
+        }
+        if o >= u {
+            u -= o;
+        } else {
+            return false;
+        }
+        u == other.unknown()
+    }
 }
 impl PartialEq for AtomData {
     fn eq(&self, other: &Self) -> bool {
@@ -274,7 +297,12 @@ impl Atom {
     /// If the first atom has no isotope or chirality and the second does, this can still return true.
     /// Otherwise, acts the same as `eq_or_r`
     pub fn matches(&self, other: &Self) -> bool {
-        if !self.data.is_compatible(other.data) {
+        if self.data.chirality() != Chirality::None
+            && self.data.chirality() != other.data.chirality()
+        {
+            return false;
+        }
+        if !self.data.compatible_one_way(other.data) {
             return false;
         }
         if self.protons == 0 {

--- a/src/core.rs
+++ b/src/core.rs
@@ -132,17 +132,17 @@ impl AtomData {
         let Some(o) = other.single().checked_sub(self.single()) else {
             return false;
         };
-        if h >= u {
+        if u >= h {
             u -= h;
         } else {
             return false;
         }
-        if o >= u {
+        if u >= o {
             u -= o;
         } else {
             return false;
         }
-        u == other.unknown()
+        u == 0
     }
 }
 impl PartialEq for AtomData {
@@ -295,7 +295,6 @@ impl Atom {
 
     /// The first atom, used in a pattern, could refer to the second.
     /// If the first atom has no isotope or chirality and the second does, this can still return true.
-    /// Otherwise, acts the same as `eq_or_r`
     pub fn matches(&self, other: &Self) -> bool {
         if self.data.chirality() != Chirality::None
             && self.data.chirality() != other.data.chirality()

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -7,6 +7,7 @@ pub mod graph_union;
 pub mod misc;
 pub mod modded;
 pub mod nodefilter;
+pub mod rangefilter;
 
 pub use algo::*;
 pub use bitfilter::BitFiltered;
@@ -14,3 +15,4 @@ pub use compact::GraphCompactor;
 pub use graph_union::GraphUnion;
 pub use modded::ModdedGraph;
 pub use nodefilter::NodeFilter;
+pub use rangefilter::RangeFiltered;

--- a/src/graph/rangefilter.rs
+++ b/src/graph/rangefilter.rs
@@ -62,10 +62,10 @@ impl<G: DataValueMap + NodeIndexable> DataValueMap for RangeFiltered<G> {
 
 impl<G: NodeIndexable> NodeIndexable for RangeFiltered<G> {
     fn from_index(&self, i: usize) -> Self::NodeId {
-        self.graph.from_index(i.saturating_sub(self.start))
+        self.graph.from_index(i + self.start)
     }
     fn to_index(&self, a: Self::NodeId) -> usize {
-        self.graph.to_index(a) + self.start
+        self.graph.to_index(a) - self.start
     }
     fn node_bound(&self) -> usize {
         self.end - self.start

--- a/src/graph/rangefilter.rs
+++ b/src/graph/rangefilter.rs
@@ -1,0 +1,234 @@
+use super::misc::DataValueMap;
+use petgraph::data::*;
+use petgraph::visit::*;
+use petgraph::Direction;
+
+#[derive(Debug, Clone, Copy)]
+pub struct RangeFiltered<G> {
+    pub graph: G,
+    pub start: usize,
+    pub end: usize,
+}
+impl<G> RangeFiltered<G> {
+    pub const fn new(graph: G, start: usize, end: usize) -> Self {
+        Self { graph, start, end }
+    }
+}
+
+impl<G: GraphBase> GraphBase for RangeFiltered<G> {
+    type EdgeId = G::EdgeId;
+    type NodeId = G::NodeId;
+}
+
+impl<G: GraphProp> GraphProp for RangeFiltered<G> {
+    type EdgeType = G::EdgeType;
+    fn is_directed(&self) -> bool {
+        self.graph.is_directed()
+    }
+}
+
+impl<G: Data> Data for RangeFiltered<G> {
+    type NodeWeight = G::NodeWeight;
+    type EdgeWeight = G::EdgeWeight;
+}
+
+impl<G: DataMap + NodeIndexable> DataMap for RangeFiltered<G> {
+    fn node_weight(&self, id: Self::NodeId) -> Option<&Self::NodeWeight> {
+        let i = self.graph.to_index(id);
+        (self.start..self.end)
+            .contains(&i)
+            .then(|| self.graph.node_weight(id))?
+    }
+    fn edge_weight(&self, id: Self::EdgeId) -> Option<&Self::EdgeWeight> {
+        self.graph.edge_weight(id)
+    }
+}
+impl<G: GraphBase + NodeIndexable> NodeCount for RangeFiltered<G> {
+    fn node_count(&self) -> usize {
+        self.end - self.start
+    }
+}
+impl<G: DataValueMap + NodeIndexable> DataValueMap for RangeFiltered<G> {
+    fn node_weight(&self, id: Self::NodeId) -> Option<Self::NodeWeight> {
+        let i = self.graph.to_index(id);
+        (self.start..self.end)
+            .contains(&i)
+            .then(|| self.graph.node_weight(id))?
+    }
+    fn edge_weight(&self, id: Self::EdgeId) -> Option<Self::EdgeWeight> {
+        self.graph.edge_weight(id)
+    }
+}
+
+impl<G: NodeIndexable> NodeIndexable for RangeFiltered<G> {
+    fn from_index(&self, i: usize) -> Self::NodeId {
+        self.graph.from_index(i.saturating_sub(self.start))
+    }
+    fn to_index(&self, a: Self::NodeId) -> usize {
+        self.graph.to_index(a) + self.start
+    }
+    fn node_bound(&self) -> usize {
+        self.end - self.start
+    }
+}
+impl<G: NodeIndexable> NodeCompactIndexable for RangeFiltered<G> {}
+
+impl<G: GetAdjacencyMatrix> GetAdjacencyMatrix for RangeFiltered<G> {
+    type AdjMatrix = G::AdjMatrix;
+
+    fn adjacency_matrix(&self) -> Self::AdjMatrix {
+        self.graph.adjacency_matrix()
+    }
+    fn is_adjacent(&self, matrix: &Self::AdjMatrix, a: Self::NodeId, b: Self::NodeId) -> bool {
+        self.graph.is_adjacent(matrix, a, b)
+    }
+}
+
+impl<'a, G: Data> IntoNodeIdentifiers for &'a RangeFiltered<G>
+where
+    &'a G: IntoNodeIdentifiers<NodeId = G::NodeId> + NodeIndexable,
+{
+    type NodeIdentifiers =
+        iter::NodeIdFilter<<&'a G as IntoNodeIdentifiers>::NodeIdentifiers, &'a G>;
+
+    fn node_identifiers(self) -> Self::NodeIdentifiers {
+        iter::NodeIdFilter(
+            self.graph.node_identifiers(),
+            &self.graph,
+            self.start,
+            self.end,
+        )
+    }
+}
+
+impl<'a, G: Data> IntoNodeReferences for &'a RangeFiltered<G>
+where
+    &'a G: IntoNodeReferences<NodeWeight = G::NodeWeight, NodeId = G::NodeId> + NodeIndexable,
+{
+    type NodeRef = <&'a G as IntoNodeReferences>::NodeRef;
+    type NodeReferences = iter::NodeRefFilter<<&'a G as IntoNodeReferences>::NodeReferences, &'a G>;
+
+    fn node_references(self) -> Self::NodeReferences {
+        iter::NodeRefFilter(
+            self.graph.node_references(),
+            &self.graph,
+            self.start,
+            self.end,
+        )
+    }
+}
+
+impl<'a, G: Data> IntoEdgeReferences for &'a RangeFiltered<G>
+where
+    &'a G: IntoEdgeReferences<EdgeId = G::EdgeId, NodeId = G::NodeId, EdgeWeight = G::EdgeWeight>
+        + NodeIndexable,
+{
+    type EdgeRef = <&'a G as IntoEdgeReferences>::EdgeRef;
+    type EdgeReferences = iter::EdgeRefFilter<<&'a G as IntoEdgeReferences>::EdgeReferences, &'a G>;
+
+    fn edge_references(self) -> Self::EdgeReferences {
+        iter::EdgeRefFilter(
+            self.graph.edge_references(),
+            &self.graph,
+            self.start,
+            self.end,
+        )
+    }
+}
+
+impl<'a, G: Data> IntoEdges for &'a RangeFiltered<G>
+where
+    &'a G: IntoEdges<EdgeId = G::EdgeId, NodeId = G::NodeId, EdgeWeight = G::EdgeWeight>
+        + NodeIndexable,
+{
+    type Edges = iter::EdgeRefFilter<<&'a G as IntoEdges>::Edges, &'a G>;
+
+    fn edges(self, a: Self::NodeId) -> Self::Edges {
+        iter::EdgeRefFilter(self.graph.edges(a), &self.graph, self.start, self.end)
+    }
+}
+
+impl<'a, G: Data> IntoNeighbors for &'a RangeFiltered<G>
+where
+    &'a G: IntoNeighbors<EdgeId = G::EdgeId, NodeId = G::NodeId> + NodeIndexable,
+{
+    type Neighbors = iter::NodeIdFilter<<&'a G as IntoNeighbors>::Neighbors, &'a G>;
+    fn neighbors(self, a: Self::NodeId) -> Self::Neighbors {
+        iter::NodeIdFilter(self.graph.neighbors(a), &self.graph, self.start, self.end)
+    }
+}
+
+impl<'a, G: Data> IntoNeighborsDirected for &'a RangeFiltered<G>
+where
+    &'a G: IntoNeighborsDirected<EdgeId = G::EdgeId, NodeId = G::NodeId> + NodeIndexable,
+{
+    type NeighborsDirected =
+        iter::NodeIdFilter<<&'a G as IntoNeighborsDirected>::NeighborsDirected, &'a G>;
+
+    fn neighbors_directed(self, a: Self::NodeId, dir: Direction) -> Self::NeighborsDirected {
+        iter::NodeIdFilter(
+            self.graph.neighbors_directed(a, dir),
+            &self.graph,
+            self.start,
+            self.end,
+        )
+    }
+}
+
+impl<'a, G: Data> IntoEdgesDirected for &'a RangeFiltered<G>
+where
+    &'a G: IntoEdgesDirected<EdgeId = G::EdgeId, NodeId = G::NodeId, EdgeWeight = G::EdgeWeight>
+        + NodeIndexable,
+{
+    type EdgesDirected = iter::EdgeRefFilter<<&'a G as IntoEdgesDirected>::EdgesDirected, &'a G>;
+
+    fn edges_directed(self, a: Self::NodeId, dir: Direction) -> Self::EdgesDirected {
+        iter::EdgeRefFilter(
+            self.graph.edges_directed(a, dir),
+            &self.graph,
+            self.start,
+            self.end,
+        )
+    }
+}
+
+#[doc(hidden)]
+pub mod iter {
+    use super::*;
+
+    pub struct NodeIdFilter<I, G>(pub I, pub G, pub usize, pub usize);
+    impl<G: NodeIndexable, I: Iterator<Item = G::NodeId>> Iterator for NodeIdFilter<I, G> {
+        type Item = G::NodeId;
+        fn next(&mut self) -> Option<G::NodeId> {
+            self.0
+                .by_ref()
+                .find(|&i| (self.2..self.3).contains(&self.1.to_index(i)))
+        }
+    }
+
+    pub struct NodeRefFilter<I, G>(pub I, pub G, pub usize, pub usize);
+    impl<G: IntoNodeReferences + NodeIndexable, I: Iterator<Item = G::NodeRef>> Iterator
+        for NodeRefFilter<I, G>
+    {
+        type Item = G::NodeRef;
+        fn next(&mut self) -> Option<G::NodeRef> {
+            self.0
+                .by_ref()
+                .find(|i| (self.2..self.3).contains(&self.1.to_index(i.id())))
+        }
+    }
+
+    pub struct EdgeRefFilter<I, G>(pub I, pub G, pub usize, pub usize);
+    impl<G: IntoEdgeReferences + NodeIndexable, I: Iterator<Item = G::EdgeRef>> Iterator
+        for EdgeRefFilter<I, G>
+    {
+        type Item = G::EdgeRef;
+        fn next(&mut self) -> Option<G::EdgeRef> {
+            self.0.by_ref().find(|i| {
+                let range = self.2..self.3;
+                range.contains(&self.1.to_index(i.source()))
+                    && range.contains(&self.1.to_index(i.target()))
+            })
+        }
+    }
+}

--- a/src/tests/misc.rs
+++ b/src/tests/misc.rs
@@ -9,8 +9,18 @@ fn atom_check() {
     let mut atom2 = Atom::new(8);
     atom2.add_hydrogens(1).unwrap();
     atom2.add_rs(1).unwrap();
+    // -oh (in a molecule)
+    let mut atom3 = Atom::new(8);
+    atom3.add_hydrogens(1).unwrap();
+    atom3.set_single_bonds(1).unwrap();
+
+    // ror
+    let mut atom4 = Atom::new(8);
+    atom4.add_rs(2).unwrap();
 
     assert_ne!(atom1, atom2);
-    assert!(atom2.matches(&atom1));
     assert!(!atom1.matches(&atom2));
+    assert!(atom2.matches(&atom1));
+    assert!(atom2.matches(&atom3));
+    assert!(atom4.matches(&atom2));
 }

--- a/src/tests/misc.rs
+++ b/src/tests/misc.rs
@@ -1,0 +1,16 @@
+use crate::core::Atom;
+
+#[test]
+fn atom_check() {
+    // h2o
+    let mut atom1 = Atom::new(8);
+    atom1.add_hydrogens(2).unwrap();
+    // roh
+    let mut atom2 = Atom::new(8);
+    atom2.add_hydrogens(1).unwrap();
+    atom2.add_rs(1).unwrap();
+
+    assert_ne!(atom1, atom2);
+    assert!(atom2.matches(&atom1));
+    assert!(!atom1.matches(&atom2));
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod macros;
 mod algo;
 mod arena;
 mod empirical;
+mod misc;
 mod molecule;
 mod smiles;
 mod utils;


### PR DESCRIPTION
Add a function that can optimize the layout of an arena, such that the fragments are all inserted in the correct order. Also, fixes a bug with `Atom::matches`.