### PR TITLE
Add a newtype for molecule indices

### DIFF
--- a/src/arena/molecule/graph_traits.rs
+++ b/src/arena/molecule/graph_traits.rs
@@ -18,12 +18,12 @@ impl<Ix: Copy + Ord, R> GraphProp for Molecule<Ix, R> {
 
 impl<Ix: IndexType + Ord, R: ArenaAccessor<Ix = Ix>> NodeCount for Molecule<Ix, R> {
     fn node_count(&self) -> usize {
-        self.arena.get_arena().parts[self.index.index()].1.index()
+        self.arena.get_arena().parts[self.index.0.index()].1.index()
     }
 }
 impl<Ix: IndexType + Ord, R: ArenaAccessor<Ix = Ix>> NodeIndexable for Molecule<Ix, R> {
     fn node_bound(&self) -> usize {
-        self.arena.get_arena().parts[self.index.index()].1.index()
+        self.arena.get_arena().parts[self.index.0.index()].1.index()
     }
     fn to_index(&self, a: NodeIndex<Ix>) -> usize {
         a.0.index()
@@ -55,7 +55,7 @@ impl<Ix: IndexType + Ord, R: ArenaAccessor<Ix = Ix> + Copy> IntoNodeReferences f
     fn node_references(self) -> Self::NodeReferences {
         iter::NodeReferences {
             range: 0..self.node_bound(),
-            mol_idx: self.index,
+            mol_idx: self.index.0,
             arena: self.arena,
         }
     }
@@ -65,7 +65,7 @@ impl<Ix: IndexType + Ord, R: ArenaAccessor<Ix = Ix> + Copy> IntoEdgeReferences f
     type EdgeReferences = iter::EdgeReferences<Ix, R>;
 
     fn edge_references(self) -> Self::EdgeReferences {
-        iter::EdgeReferences::new(self.index, self.arena)
+        iter::EdgeReferences::new(self.index.0, self.arena)
     }
 }
 impl<Ix: IndexType + Ord, R: ArenaAccessor<Ix = Ix> + Copy> IntoEdges for Molecule<Ix, R> {
@@ -73,7 +73,7 @@ impl<Ix: IndexType + Ord, R: ArenaAccessor<Ix = Ix> + Copy> IntoEdges for Molecu
 
     fn edges(self, a: Self::NodeId) -> Self::Edges {
         iter::EdgesDirected(
-            iter::Edges::new(self.index, a.0, self.arena),
+            iter::Edges::new(self.index.0, a.0, self.arena),
             Direction::Outgoing,
         )
     }
@@ -82,14 +82,14 @@ impl<Ix: IndexType + Ord, R: ArenaAccessor<Ix = Ix> + Copy> IntoEdgesDirected fo
     type EdgesDirected = iter::EdgesDirected<Ix, R>;
 
     fn edges_directed(self, a: Self::NodeId, dir: Direction) -> Self::EdgesDirected {
-        iter::EdgesDirected(iter::Edges::new(self.index, a.0, self.arena), dir)
+        iter::EdgesDirected(iter::Edges::new(self.index.0, a.0, self.arena), dir)
     }
 }
 impl<Ix: IndexType + Ord, R: ArenaAccessor<Ix = Ix> + Copy> IntoNeighbors for Molecule<Ix, R> {
     type Neighbors = iter::Neighbors<Ix, R>;
 
     fn neighbors(self, a: Self::NodeId) -> Self::Neighbors {
-        iter::Neighbors(iter::Edges::new(self.index, a.0, self.arena))
+        iter::Neighbors(iter::Edges::new(self.index.0, a.0, self.arena))
     }
 }
 impl<Ix: IndexType + Ord, R: ArenaAccessor<Ix = Ix> + Copy> IntoNeighborsDirected
@@ -98,7 +98,7 @@ impl<Ix: IndexType + Ord, R: ArenaAccessor<Ix = Ix> + Copy> IntoNeighborsDirecte
     type NeighborsDirected = iter::Neighbors<Ix, R>;
 
     fn neighbors_directed(self, n: Self::NodeId, _dir: Direction) -> Self::NeighborsDirected {
-        iter::Neighbors(iter::Edges::new(self.index, n.0, self.arena))
+        iter::Neighbors(iter::Edges::new(self.index.0, n.0, self.arena))
     }
 }
 impl<Ix: IndexType + Ord, R: ArenaAccessor<Ix = Ix> + Copy> GetAdjacencyMatrix for Molecule<Ix, R> {
@@ -159,7 +159,7 @@ pub mod iter {
         fn next(&mut self) -> Option<Self::Item> {
             self.range
                 .next()
-                .map(|i| NodeReference::new(self.mol_idx, NodeIndex(Ix::new(i)), self.arena))
+                .map(|i| NodeReference::new(self.mol_idx.into(), NodeIndex(Ix::new(i)), self.arena))
         }
     }
 

--- a/src/arena/molecule/node_impls.rs
+++ b/src/arena/molecule/node_impls.rs
@@ -79,7 +79,11 @@ pub struct NodeReference<Ix> {
     pub atom: Atom,
 }
 impl<Ix> NodeReference<Ix> {
-    pub fn new<R: ArenaAccessor<Ix = Ix>>(mol_idx: Ix, node_idx: NodeIndex<Ix>, arena: R) -> Self
+    pub fn new<R: ArenaAccessor<Ix = Ix>>(
+        mol_idx: MolIndex<Ix>,
+        node_idx: NodeIndex<Ix>,
+        arena: R,
+    ) -> Self
     where
         Ix: IndexType,
     {
@@ -121,7 +125,12 @@ pub struct EdgeReference<Ix> {
     pub target_first: bool,
 }
 impl<Ix: PartialOrd> EdgeReference<Ix> {
-    pub fn new<R: ArenaAccessor<Ix = Ix>>(mol_idx: Ix, source: Ix, target: Ix, arena: R) -> Self
+    pub fn new<R: ArenaAccessor<Ix = Ix>>(
+        mol_idx: MolIndex<Ix>,
+        source: Ix,
+        target: Ix,
+        arena: R,
+    ) -> Self
     where
         Ix: IndexType,
     {

--- a/src/bin/repl.rs
+++ b/src/bin/repl.rs
@@ -280,7 +280,7 @@ fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError
                 };
                 let s = if let Some(inputs) = args.get_many::<u32>("mol") {
                     generate_smiles(
-                        &GraphUnion(inputs.map(|i| ctx.arena.molecule(*i)).collect()),
+                        &GraphUnion(inputs.map(|&i| ctx.arena.molecule(i.into())).collect()),
                         cfg,
                     )
                 } else {
@@ -317,7 +317,7 @@ fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError
                 };
                 let s = if let Some(inputs) = args.get_many::<u32>("mol") {
                     SvgFormatter {
-                        graph: &GraphUnion(inputs.map(|i| ctx.arena.molecule(*i)).collect()),
+                        graph: &GraphUnion(inputs.map(|&i| ctx.arena.molecule(i.into())).collect()),
                         mode,
                     }
                     .to_string()
@@ -347,7 +347,7 @@ fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError
                 };
                 let s = if let Some(inputs) = args.get_many::<u32>("mol") {
                     SvgFormatter {
-                        graph: &GraphUnion(inputs.map(|i| ctx.arena.molecule(*i)).collect()),
+                        graph: &GraphUnion(inputs.map(|&i| ctx.arena.molecule(i.into())).collect()),
                         mode,
                     }
                     .render(None)

--- a/src/tests/arena/insert.rs
+++ b/src/tests/arena/insert.rs
@@ -19,8 +19,7 @@ fn isomorphism() {
     use petgraph::{Incoming, Outgoing};
     let mut arena = Arena::<u32>::new();
     let acid = smiles!("OS(=O)(=O)O");
-    let ix = arena.insert_mol(&acid);
-    let ins_acid = arena.molecule(ix);
+    let ins_acid = arena.insert_mol(&acid).in_arena(&arena);
     println!("before");
     for node in acid.node_identifiers() {
         println!("{node:?}");
@@ -63,7 +62,7 @@ fn alcohols() {
 
     let alcohol = arena.insert_mol(&smiles!("O&"));
     tracing::info!("alcohol inserted");
-    assert_eq!(alcohol, 0);
+    assert_eq!(alcohol.index(), 0);
     assert_eq!(orig.len(), arena.parts.len(), "arena length changed");
     assert!(orig == arena.parts, "arena changed");
 


### PR DESCRIPTION
A lot of arena methods would return and use `Ix`, but it's unclear what that actually means when substituted for a concrete type. This adds a newtype that
- isn't meant to be used as a number (directly)
- communicates its purpose
- has methods to easily get the corresponding `Molecule`