### PR TITLE
Allow custom data to be stored with fragments

### DIFF
--- a/src/arena/molecule/mod.rs
+++ b/src/arena/molecule/mod.rs
@@ -58,6 +58,20 @@ impl<Ix, R> Molecule<Ix, R> {
 }
 
 impl<Ix: IndexType, R: ArenaAccessor<Ix = Ix>> Molecule<Ix, R> {
+    pub fn data(&self) -> R::MappedRef<'_, R::Data> {
+        R::map_ref(self.arena(), |a| &a.frags[self.index.index()].custom)
+    }
+    pub fn data_mut(&self) -> R::MappedRefMut<'_, R::Data>
+    where
+        R: ArenaAccessorMut,
+    {
+        R::map_ref_mut(self.arena_mut(), |a| {
+            &mut a.frags[self.index.index()].custom
+        })
+    }
+}
+
+impl<Ix: IndexType, R: ArenaAccessor<Ix = Ix>> Molecule<Ix, R> {
     /// Check if this molecule contains the underlying group.
     pub fn contains(&self, group: MolIndex<Ix>) -> bool {
         self.arena.get_arena().contains_group(self.index, group)

--- a/src/bin/repl.rs
+++ b/src/bin/repl.rs
@@ -266,7 +266,7 @@ fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError
             println!("{:#?}", ctx.arena.graph());
         }
         if *args.get_one("frags").unwrap_or(&false) {
-            println!("{:#?}", ctx.arena.expose_parts());
+            println!("{:#?}", ctx.arena.expose_frags());
         }
         let Some(dump_ty) = args.get_one::<DumpType>("type") else {
             return Ok(Some(String::new()));
@@ -300,10 +300,10 @@ fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError
                         if !out.is_empty() {
                             out.push('\n');
                         }
-                        let _ = write!(out, "{:#?}", ctx.arena.expose_part(*i as _));
+                        let _ = write!(out, "{:#?}", ctx.arena.expose_frags()[*i as usize]);
                     }
                 } else {
-                    let _ = write!(out, "{:#?}", ctx.arena.expose_parts());
+                    let _ = write!(out, "{:#?}", ctx.arena.expose_frags());
                 }
                 Ok(Some(out))
             }

--- a/src/tests/arena/insert.rs
+++ b/src/tests/arena/insert.rs
@@ -58,23 +58,23 @@ fn alcohols() {
         smiles!("CC(C)O"), // isopropanol
     );
     tracing::info!("arena created");
-    let orig = arena.parts.clone();
+    let orig = arena.frags.clone();
 
     let alcohol = arena.insert_mol(&smiles!("O&"));
     tracing::info!("alcohol inserted");
     assert_eq!(alcohol.index(), 0);
-    assert_eq!(orig.len(), arena.parts.len(), "arena length changed");
-    assert!(orig == arena.parts, "arena changed");
+    assert_eq!(orig.len(), arena.frags.len(), "arena length changed");
+    assert!(orig == arena.frags, "arena changed");
 
     let isp_idx = arena.insert_mol(&smiles!("CC(C)O"));
     tracing::info!("isopropanol inserted");
     let isp = arena.molecule(isp_idx);
 
-    println!("{:#?}", arena.parts);
+    println!("{:#?}", arena.frags);
 
     // if these aren't equal, the output is just ugly
-    assert_eq!(orig.len(), arena.parts.len(), "arena length changed");
-    assert!(orig == arena.parts, "arena changed");
+    assert_eq!(orig.len(), arena.frags.len(), "arena length changed");
+    assert!(orig == arena.frags, "arena changed");
 
     assert!(isp.contains(alcohol));
 }

--- a/src/tests/arena/insert/order.rs
+++ b/src/tests/arena/insert/order.rs
@@ -27,8 +27,6 @@ fn small_med_large() {
     let ester = arena.insert_mol(&smiles!("C&(=O)O&"));
     let methyl_acetate = arena.insert_mol(&smiles!("CC(=O)OC"));
 
-    println!("{:#?}", arena.expose_parts());
-
     assert!(arena.contains_group(ester, ether));
     assert!(arena.contains_group(ester, ketone));
     assert!(arena.contains_group(methyl_acetate, ether));
@@ -44,8 +42,6 @@ fn small_large_med() {
     let methyl_acetate = arena.insert_mol(&smiles!("CC(=O)OC"));
     let ketone = arena.insert_mol(&smiles!("C&&=O"));
     let ester = arena.insert_mol(&smiles!("C&(=O)O&"));
-
-    println!("{:#?}", arena.expose_parts());
 
     assert!(arena.contains_group(ester, ether));
     assert!(arena.contains_group(ester, ketone));
@@ -63,8 +59,6 @@ fn large_med_small() {
     let ether = arena.insert_mol(&smiles!("O&&"));
     let ketone = arena.insert_mol(&smiles!("C&&=O"));
 
-    println!("{:#?}", arena.expose_parts());
-
     assert!(arena.contains_group(ester, ether));
     assert!(arena.contains_group(ester, ketone));
     assert!(arena.contains_group(methyl_acetate, ether));
@@ -81,8 +75,6 @@ fn large_small_med() {
     let ketone = arena.insert_mol(&smiles!("C&&=O"));
     let ester = arena.insert_mol(&smiles!("C&(=O)O&"));
 
-    println!("{arena:#?}");
-
     assert!(arena.contains_group(ester, ether));
     assert!(arena.contains_group(ester, ketone));
     assert!(arena.contains_group(methyl_acetate, ether));
@@ -98,8 +90,6 @@ fn large_small_med_small() {
     let ether = arena.insert_mol(&smiles!("O&&"));
     let ester = arena.insert_mol(&smiles!("C&(=O)O&"));
     let ketone = arena.insert_mol(&smiles!("C&&=O"));
-
-    println!("{:#?}", arena.expose_parts());
 
     assert!(arena.contains_group(ester, ether));
     assert!(arena.contains_group(ester, ketone));


### PR DESCRIPTION
Change the fragment type to a proper struct rather than just a tuple, and allow generic data to be stored with each fragment.