### PR TITLE
Store atoms contiguously

### DIFF
--- a/examples/arena-test.rs
+++ b/examples/arena-test.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use lute::graph::semicompact::GraphNodeAlloc;
+use lute::graph::semisparse::SemiSparseGraph;
 use lute::prelude::*;
 use std::path::PathBuf;
 
@@ -50,7 +50,7 @@ fn main() {
     }
 
     let graph =
-        lute::graph::GraphCompactor::<&GraphNodeAlloc<Atom, Bond, _, u16>>::new(arena.graph());
+        lute::graph::GraphCompactor::<&SemiSparseGraph<Atom, Bond, _, u16>>::new(arena.graph());
 
     match cli.fmt {
         OutputType::None => {}

--- a/examples/arena-test.rs
+++ b/examples/arena-test.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
+use lute::graph::semicompact::GraphNodeAlloc;
 use lute::prelude::*;
-use petgraph::prelude::*;
 use std::path::PathBuf;
 
 mod common;
@@ -49,7 +49,8 @@ fn main() {
         eprintln!("arena: {:#?}", arena.expose_frags());
     }
 
-    let graph = lute::graph::GraphCompactor::<&UnGraph<Atom, Bond, u16>>::new(&arena.graph().inner);
+    let graph =
+        lute::graph::GraphCompactor::<&GraphNodeAlloc<Atom, Bond, _, u16>>::new(arena.graph());
 
     match cli.fmt {
         OutputType::None => {}

--- a/examples/arena-test.rs
+++ b/examples/arena-test.rs
@@ -49,7 +49,7 @@ fn main() {
         eprintln!("arena: {:#?}", arena.expose_frags());
     }
 
-    let graph = lute::graph::GraphCompactor::<&StableUnGraph<Atom, Bond, u16>>::new(arena.graph());
+    let graph = lute::graph::GraphCompactor::<&UnGraph<Atom, Bond, u16>>::new(&arena.graph().inner);
 
     match cli.fmt {
         OutputType::None => {}

--- a/src/arena/arena.rs
+++ b/src/arena/arena.rs
@@ -882,7 +882,7 @@ impl<Ix: IndexType, D: Default> Arena<Ix, D> {
                 if a == IndexType::max() || b == IndexType::max() {
                     continue;
                 }
-                self.graph.inner.add_edge(
+                self.graph.add_edge(
                     NodeIndex::new(start + a),
                     NodeIndex::new(start + b),
                     *e.weight(),

--- a/src/arena/arena.rs
+++ b/src/arena/arena.rs
@@ -8,7 +8,7 @@ use misc::DataValueMap;
 use petgraph::graph::DefaultIx;
 use petgraph::prelude::*;
 use petgraph::visit::*;
-use semicompact::GraphNodeAlloc;
+use semisparse::SemiSparseGraph;
 use slab::Slab;
 use smallvec::SmallVec;
 use std::cell::{Cell, UnsafeCell};
@@ -64,7 +64,7 @@ impl<Ix: Debug> Debug for Range<Ix> {
 }
 
 const ATOM_BIT_STORAGE: usize = 2;
-type Graph<Ix> = GraphNodeAlloc<Atom, Bond, Undirected, Ix>;
+type Graph<Ix> = SemiSparseGraph<Atom, Bond, Undirected, Ix>;
 type BSType = crate::utils::bitset::BitSet<u16, ATOM_BIT_STORAGE>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/arena/molecule/graph_traits.rs
+++ b/src/arena/molecule/graph_traits.rs
@@ -219,7 +219,7 @@ pub mod iter {
                     }
                     MolRepr::Atomic(ref b) => {
                         let offset = off.index();
-                        let mut it = arena.graph().inner.edge_references().filter_map(|e| {
+                        let mut it = arena.graph().graph().edge_references().filter_map(|e| {
                             let s = b.index(e.source().index())?;
                             let t = b.index(e.target().index())?;
                             Some(EdgeReference::with_weight(
@@ -300,14 +300,14 @@ pub mod iter {
                         if !matches!(self.state, State::Atomic(_)) {
                             let i = b.nth(self.atom_idx.index())?;
                             trace!(id = i, "initializing walker at atomic level");
-                            let w = arena.graph().inner.neighbors(PetIndex::new(i)).detach();
+                            let w = arena.graph().graph().neighbors(PetIndex::new(i)).detach();
                             self.state = State::Atomic(w);
                         }
                         let State::Atomic(w) = &mut self.state else {
                             unreachable!()
                         };
 
-                        while let Some((e, n)) = w.next(&arena.graph().inner) {
+                        while let Some((e, n)) = w.next(arena.graph().graph()) {
                             let Some(idx) = b.index(n.index()) else {
                                 continue;
                             };
@@ -317,7 +317,7 @@ pub mod iter {
                             return Some(EdgeReference::with_weight(
                                 self.orig_idx,
                                 Ix::new(offset),
-                                arena.graph().inner[e],
+                                arena.graph()[e],
                             ));
                         }
                         return None;

--- a/src/arena/molecule/graph_traits.rs
+++ b/src/arena/molecule/graph_traits.rs
@@ -142,7 +142,7 @@ impl<Ix: IndexType + Ord, R> Visitable for Molecule<Ix, R> {
 
 pub mod iter {
     use super::*;
-    use petgraph::stable_graph::WalkNeighbors;
+    use petgraph::graph::WalkNeighbors;
     use smallvec::{smallvec, SmallVec};
     use std::fmt::{self, Debug, Formatter};
 
@@ -219,7 +219,7 @@ pub mod iter {
                     }
                     MolRepr::Atomic(ref b) => {
                         let offset = off.index();
-                        let mut it = arena.graph().edge_references().filter_map(|e| {
+                        let mut it = arena.graph().inner.edge_references().filter_map(|e| {
                             let s = b.index(e.source().index())?;
                             let t = b.index(e.target().index())?;
                             Some(EdgeReference::with_weight(
@@ -300,14 +300,14 @@ pub mod iter {
                         if !matches!(self.state, State::Atomic(_)) {
                             let i = b.nth(self.atom_idx.index())?;
                             trace!(id = i, "initializing walker at atomic level");
-                            let w = arena.graph().neighbors(Ix::new(i).into()).detach();
+                            let w = arena.graph().inner.neighbors(PetIndex::new(i)).detach();
                             self.state = State::Atomic(w);
                         }
                         let State::Atomic(w) = &mut self.state else {
                             unreachable!()
                         };
 
-                        while let Some((e, n)) = w.next(arena.graph()) {
+                        while let Some((e, n)) = w.next(&arena.graph().inner) {
                             let Some(idx) = b.index(n.index()) else {
                                 continue;
                             };
@@ -317,7 +317,7 @@ pub mod iter {
                             return Some(EdgeReference::with_weight(
                                 self.orig_idx,
                                 Ix::new(offset),
-                                arena.graph()[e],
+                                arena.graph().inner[e],
                             ));
                         }
                         return None;

--- a/src/arena/molecule/mod.rs
+++ b/src/arena/molecule/mod.rs
@@ -106,7 +106,7 @@ impl<Ix: IndexType, R: ArenaAccessor<Ix = Ix>> Molecule<Ix, R> {
                     let i = b.nth(idx)?;
                     return Some((
                         Ix::new(i),
-                        oride.unwrap_or_else(|| arena.graph().inner[PetIndex::new(i)]),
+                        oride.unwrap_or_else(|| arena.graph()[PetIndex::new(i)]),
                     ));
                 }
                 MolRepr::Broken(b) => {
@@ -158,7 +158,7 @@ impl<Ix: IndexType, R: ArenaAccessor<Ix = Ix>> Molecule<Ix, R> {
                 }
                 MolRepr::Atomic(b) => {
                     let i = b.nth(idx)?;
-                    let mut atom = arena.graph().inner[PetIndex::new(i)];
+                    let mut atom = arena.graph()[PetIndex::new(i)];
                     let _ = atom.unknown_to_single(cvt_singles);
                     return Some(atom);
                 }
@@ -218,11 +218,9 @@ impl<Ix: IndexType, R: ArenaAccessor<Ix = Ix>> Molecule<Ix, R> {
                 MolRepr::TempEmpty => None?,
                 MolRepr::Modify(m) => ix = m.base,
                 MolRepr::Atomic(b) => {
-                    // inefficient, but works
                     let i0 = b.nth(idx0)?;
                     let i1 = b.nth(idx1)?;
-                    // let [i0, i1] = b.nth_many_short([idx0, idx1])?;
-                    let g = &arena.graph().inner;
+                    let g = arena.graph();
                     return Some(g[g.find_edge(PetIndex::new(i0), PetIndex::new(i1))?]);
                 }
                 MolRepr::Broken(b) => {

--- a/src/arena/molecule/mod.rs
+++ b/src/arena/molecule/mod.rs
@@ -1,5 +1,6 @@
 use super::arena::*;
 use super::*;
+use petgraph::graph::NodeIndex as PetIndex;
 use petgraph::visit::IntoNodeReferences;
 
 pub mod graph_traits;
@@ -105,7 +106,7 @@ impl<Ix: IndexType, R: ArenaAccessor<Ix = Ix>> Molecule<Ix, R> {
                     let i = b.nth(idx)?;
                     return Some((
                         Ix::new(i),
-                        oride.unwrap_or_else(|| arena.graph()[petgraph::graph::NodeIndex::new(i)]),
+                        oride.unwrap_or_else(|| arena.graph().inner[PetIndex::new(i)]),
                     ));
                 }
                 MolRepr::Broken(b) => {
@@ -157,7 +158,7 @@ impl<Ix: IndexType, R: ArenaAccessor<Ix = Ix>> Molecule<Ix, R> {
                 }
                 MolRepr::Atomic(b) => {
                     let i = b.nth(idx)?;
-                    let mut atom = arena.graph()[petgraph::graph::NodeIndex::new(i)];
+                    let mut atom = arena.graph().inner[PetIndex::new(i)];
                     let _ = atom.unknown_to_single(cvt_singles);
                     return Some(atom);
                 }
@@ -221,8 +222,8 @@ impl<Ix: IndexType, R: ArenaAccessor<Ix = Ix>> Molecule<Ix, R> {
                     let i0 = b.nth(idx0)?;
                     let i1 = b.nth(idx1)?;
                     // let [i0, i1] = b.nth_many_short([idx0, idx1])?;
-                    let g = arena.graph();
-                    return Some(g[g.find_edge(Ix::new(i0).into(), Ix::new(i1).into())?]);
+                    let g = &arena.graph().inner;
+                    return Some(g[g.find_edge(PetIndex::new(i0), PetIndex::new(i1))?]);
                 }
                 MolRepr::Broken(b) => {
                     let mut ibs = ahash::AHashMap::<InterFragBond<Ix>, ()>::new();

--- a/src/bin/repl.rs
+++ b/src/bin/repl.rs
@@ -5,6 +5,7 @@ use petgraph::data::FromElements;
 use petgraph::prelude::*;
 use reedline_repl_rs::{self as rlr, Repl};
 use rlr::clap::{self, Arg, ArgAction, ArgMatches, Command, Parser, ValueEnum};
+use semicompact::GraphNodeAlloc;
 use std::env;
 use std::ffi::OsStr;
 use std::fmt::Write;
@@ -284,7 +285,7 @@ fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError
                         cfg,
                     )
                 } else {
-                    generate_smiles(&ctx.arena.graph().inner, cfg)
+                    generate_smiles(ctx.arena.graph(), cfg)
                 };
                 if let Some(p) = path {
                     std::fs::write(p, s)?;
@@ -323,7 +324,9 @@ fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError
                     .to_string()
                 } else {
                     SvgFormatter {
-                        graph: &ctx.arena.graph().inner,
+                        graph: &GraphCompactor::<&GraphNodeAlloc<_, _, _, _>>::new(
+                            ctx.arena.graph(),
+                        ),
                         mode,
                     }
                     .to_string()
@@ -351,7 +354,9 @@ fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError
                     .render(None)
                 } else {
                     SvgFormatter {
-                        graph: &ctx.arena.graph().inner,
+                        graph: &GraphCompactor::<&GraphNodeAlloc<_, _, _, _>>::new(
+                            ctx.arena.graph(),
+                        ),
                         mode,
                     }
                     .render(None)

--- a/src/bin/repl.rs
+++ b/src/bin/repl.rs
@@ -5,7 +5,7 @@ use petgraph::data::FromElements;
 use petgraph::prelude::*;
 use reedline_repl_rs::{self as rlr, Repl};
 use rlr::clap::{self, Arg, ArgAction, ArgMatches, Command, Parser, ValueEnum};
-use semicompact::GraphNodeAlloc;
+use semisparse::SemiSparseGraph;
 use std::env;
 use std::ffi::OsStr;
 use std::fmt::Write;
@@ -324,7 +324,7 @@ fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError
                     .to_string()
                 } else {
                     SvgFormatter {
-                        graph: &GraphCompactor::<&GraphNodeAlloc<_, _, _, _>>::new(
+                        graph: &GraphCompactor::<&SemiSparseGraph<_, _, _, _>>::new(
                             ctx.arena.graph(),
                         ),
                         mode,
@@ -354,7 +354,7 @@ fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError
                     .render(None)
                 } else {
                     SvgFormatter {
-                        graph: &GraphCompactor::<&GraphNodeAlloc<_, _, _, _>>::new(
+                        graph: &GraphCompactor::<&SemiSparseGraph<_, _, _, _>>::new(
                             ctx.arena.graph(),
                         ),
                         mode,

--- a/src/bin/repl.rs
+++ b/src/bin/repl.rs
@@ -99,7 +99,7 @@ impl clap::builder::TypedValueParser for SetParser {
         let val = value
             .to_str()
             .ok_or_else(|| Error::new(ErrorKind::InvalidUtf8).with_cmd(cmd))?;
-        let mode = match val.as_bytes().get(0) {
+        let mode = match val.as_bytes().first() {
             Some(&b'+') => FlagKind::Enable,
             Some(&b'-') => FlagKind::Disable,
             Some(&b'?') => FlagKind::Query,
@@ -284,10 +284,10 @@ fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError
                         cfg,
                     )
                 } else {
-                    generate_smiles(ctx.arena.graph(), cfg)
+                    generate_smiles(&ctx.arena.graph().inner, cfg)
                 };
                 if let Some(p) = path {
-                    std::fs::write(&p, s)?;
+                    std::fs::write(p, s)?;
                     Ok(Some(format!("saved to {}", p.display())))
                 } else {
                     Ok(Some(s))
@@ -323,15 +323,13 @@ fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError
                     .to_string()
                 } else {
                     SvgFormatter {
-                        graph: &GraphCompactor::<&StableUnGraph<Atom, Bond>>::new(
-                            ctx.arena.graph(),
-                        ),
+                        graph: &ctx.arena.graph().inner,
                         mode,
                     }
                     .to_string()
                 };
                 if let Some(p) = path {
-                    std::fs::write(&p, s)?;
+                    std::fs::write(p, s)?;
                     Ok(Some(format!("saved to {}", p.display())))
                 } else {
                     Ok(Some(s))
@@ -353,15 +351,13 @@ fn dump(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>, ReplError
                     .render(None)
                 } else {
                     SvgFormatter {
-                        graph: &GraphCompactor::<&StableUnGraph<Atom, Bond>>::new(
-                            ctx.arena.graph(),
-                        ),
+                        graph: &ctx.arena.graph().inner,
                         mode,
                     }
                     .render(None)
                 };
                 if let Some(p) = path {
-                    s.save_png(&p).map_err(Box::from)?;
+                    s.save_png(p).map_err(Box::from)?;
                     Ok(Some(format!("saved to {}", p.display())))
                 } else {
                     Err(ReplError::PngToStdout)
@@ -653,7 +649,6 @@ fn adjust_settings(args: ArgMatches, ctx: &mut Context) -> Result<Option<String>
     })
 }
 
-///
 #[derive(Debug, Parser)]
 struct Cli {
     /// File to load for command history

--- a/src/graph/graphs/mod.rs
+++ b/src/graph/graphs/mod.rs
@@ -3,7 +3,7 @@ pub mod compact;
 pub mod graph_union;
 pub mod nodefilter;
 pub mod rangefilter;
-pub mod semicompact;
+pub mod semisparse;
 
 pub use bitfilter::BitFiltered;
 pub use compact::GraphCompactor;

--- a/src/graph/graphs/mod.rs
+++ b/src/graph/graphs/mod.rs
@@ -3,6 +3,7 @@ pub mod compact;
 pub mod graph_union;
 pub mod nodefilter;
 pub mod rangefilter;
+pub mod semicompact;
 
 pub use bitfilter::BitFiltered;
 pub use compact::GraphCompactor;

--- a/src/graph/graphs/semicompact.rs
+++ b/src/graph/graphs/semicompact.rs
@@ -1,6 +1,5 @@
 use itertools::Itertools;
 use petgraph::graph::{EdgeIndex, Graph, IndexType, NodeIndex};
-use petgraph::visit::NodeCount;
 use petgraph::{Direction, EdgeType};
 
 /// A trait for types acting like `Option`. Mostly here for its special impl for `Atom`, which uses a scratch bit.

--- a/src/graph/graphs/semicompact.rs
+++ b/src/graph/graphs/semicompact.rs
@@ -1,0 +1,183 @@
+use itertools::Itertools;
+use petgraph::graph::{EdgeIndex, Graph, IndexType, NodeIndex};
+use petgraph::{Direction, EdgeType};
+
+/// A trait for types acting like `Option`. Mostly here for its special impl for `Atom`, which uses a scratch bit.
+pub trait Optional {
+    type Inner;
+
+    fn is_some(&self) -> bool;
+    /// Create a version of this type that's empty
+    fn none() -> Self;
+    /// Create a version of this type
+    fn some(val: Self::Inner) -> Self;
+}
+impl Optional for crate::core::Atom {
+    type Inner = Self;
+
+    fn is_some(&self) -> bool {
+        self.data.scratch() & (1 << 6) == 0
+    }
+    fn none() -> Self {
+        Self::new_scratch(0, 1 << 6)
+    }
+    fn some(mut val: Self::Inner) -> Self {
+        val.map_scratch(|s| s & ((1 << 6) - 1));
+        val
+    }
+}
+impl<T> Optional for Option<T> {
+    type Inner = T;
+
+    fn is_some(&self) -> bool {
+        Option::is_some(self)
+    }
+    fn none() -> Self {
+        None
+    }
+    fn some(val: T) -> Self {
+        Some(val)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SemiCompactGraph<N, E, Ty: EdgeType, Ix: IndexType> {
+    /// The underlying graph we use for storage
+    inner: Graph<N, E, Ty, Ix>,
+    /// Holes we've created in the graph
+    holes: [[Ix; 2]; 8],
+}
+impl<N, E, Ty: EdgeType, Ix: IndexType> SemiCompactGraph<N, E, Ty, Ix> {
+    /// Create a new semi-connected graph with a given capacity
+    pub fn with_capacity(nodes: usize, edges: usize) -> Self {
+        Self {
+            inner: Graph::with_capacity(nodes, edges),
+            holes: [[IndexType::max(); 2]; 8],
+        }
+    }
+
+    /// Create a new semi-connected graph from an underlying graph, assuming that all elements are in the "filled" state.
+    pub fn from_compact(graph: Graph<N, E, Ty, Ix>) -> Self {
+        Self {
+            inner: graph,
+            holes: [[IndexType::max(); 2]; 8],
+        }
+    }
+
+    #[inline(always)]
+    pub fn graph(&self) -> &Graph<N, E, Ty, Ix> {
+        &self.inner
+    }
+}
+impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> SemiCompactGraph<N, E, Ty, Ix> {
+    /// Allocate a contiguous range of nodes, returns the index of the first one.
+    pub fn allocate_range(&mut self, size: usize, mut fill: impl FnMut() -> N::Inner) -> usize {
+        if size == 0 {
+            return 0;
+        }
+        let best = self
+            .holes
+            .iter()
+            .enumerate()
+            .filter_map(|(n, &r @ [from, to])| {
+                let sz = to.index() - from.index();
+                (sz >= size).then_some((n, r, sz))
+            })
+            .min_by_key(|x| size.abs_diff(x.2 * 2));
+        if let Some((i, [from, _to], sz)) = best {
+            let start = from.index();
+            for i in start..(start + size) {
+                let elem = self.inner.node_weight_mut(Ix::new(i).into()).unwrap();
+                debug_assert!(!elem.is_some(), "overwrite of element detected!");
+                *elem = N::some(fill());
+            }
+            if sz > size {
+                self.holes[i][0] = Ix::new(start + size);
+            } else {
+                self.holes[i..].rotate_left(1);
+                self.update_holes(1);
+            }
+            for i in start..(start + size) {
+                self.inner[NodeIndex::new(i)] = N::some(fill());
+            }
+            start
+        } else {
+            let start = self.inner.node_count();
+            self.inner.reserve_nodes(size);
+            for _ in 0..size {
+                self.inner.add_node(N::some(fill()));
+            }
+            start
+        }
+    }
+
+    pub fn free_range(&mut self, start: usize, end: usize) {
+        for i in start..end {
+            self.inner[NodeIndex::new(i)] = N::none();
+            self.detach_node(i);
+        }
+        let mut merge_to: Option<&mut Ix> = None;
+        let mut rotate = None;
+        for (i, [s, e]) in self.holes.iter_mut().enumerate() {
+            if s.index() == end {
+                if let Some(s2) = merge_to {
+                    *s2 = *s;
+                    rotate = Some(i);
+                    break;
+                } else {
+                    *s = Ix::new(start);
+                    merge_to = Some(e);
+                }
+            } else if e.index() == start {
+                if let Some(e2) = merge_to {
+                    *e2 = *e;
+                    rotate = Some(i);
+                    break;
+                } else {
+                    *e = Ix::new(end);
+                    merge_to = Some(s);
+                }
+            }
+        }
+        if let Some(i) = rotate {
+            self.holes[i..].rotate_left(1);
+        }
+        self.update_holes(1);
+    }
+
+    /// Remove all edges from a node.
+    fn detach_node(&mut self, idx: usize) {
+        let mut next = self.inner.raw_nodes()[idx].next_edge(Direction::Outgoing);
+        while next != EdgeIndex::end() {
+            next = self.inner.raw_nodes()[idx].next_edge(Direction::Outgoing);
+            self.inner.remove_edge(next);
+        }
+        next = self.inner.raw_nodes()[idx].next_edge(Direction::Incoming);
+        while next != EdgeIndex::end() {
+            next = self.inner.raw_nodes()[idx].next_edge(Direction::Incoming);
+            self.inner.remove_edge(next);
+        }
+    }
+
+    /// Update our hole list, with last being the number of elements from the end that we need to check
+    fn update_holes(&mut self, last: usize) {
+        let hlen = self.holes.len();
+        let start_ix = self.holes[hlen - last - 1][0].index();
+        let empty = [IndexType::max(); 2];
+        let chunks = self.inner.raw_nodes()[start_ix..]
+            .iter()
+            .enumerate()
+            .chunk_by(|n| !n.1.weight.is_some());
+        let mut iter = chunks.into_iter().filter_map(|(p, mut g)| {
+            p.then(|| -> Option<_> {
+                let start = g.next()?.0;
+                let end = g.last()?.0;
+                Some([start + start_ix, end + start_ix])
+            })
+            .flatten()
+        });
+        for hole in &mut self.holes[(hlen - last)..] {
+            *hole = iter.next().map_or(empty, |arr| arr.map(Ix::new));
+        }
+    }
+}

--- a/src/graph/graphs/semisparse.rs
+++ b/src/graph/graphs/semisparse.rs
@@ -63,14 +63,14 @@ impl<T> Optional for Option<T> {
 /// A type that "allocates" runs of contiguous nodes.
 /// Might make this a full graph type later, for now it's just a thin wrapper that you could mess up
 #[derive(Debug, Clone)]
-pub struct GraphNodeAlloc<N, E, Ty: EdgeType, Ix: IndexType> {
+pub struct SemiSparseGraph<N, E, Ty: EdgeType, Ix: IndexType> {
     /// The underlying graph we use for storage
     inner: Graph<N, E, Ty, Ix>,
     /// Holes we've created in the graph
     holes: [[Ix; 2]; 8],
     node_count: usize,
 }
-impl<N, E, Ty: EdgeType, Ix: IndexType> GraphNodeAlloc<N, E, Ty, Ix> {
+impl<N, E, Ty: EdgeType, Ix: IndexType> SemiSparseGraph<N, E, Ty, Ix> {
     pub fn new() -> Self {
         Self::with_capacity(0, 0)
     }
@@ -103,7 +103,7 @@ impl<N, E, Ty: EdgeType, Ix: IndexType> GraphNodeAlloc<N, E, Ty, Ix> {
         &self.inner
     }
 }
-impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> GraphNodeAlloc<N, E, Ty, Ix> {
+impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> SemiSparseGraph<N, E, Ty, Ix> {
     /// Allocate a contiguous range of nodes, returns the index of the first one.
     pub fn allocate_range(&mut self, size: usize, mut fill: impl FnMut() -> N::Inner) -> usize {
         if size == 0 {
@@ -247,13 +247,13 @@ impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> GraphNodeAlloc<N, E, Ty, Ix> {
         self.inner.find_edge(a, b)
     }
 }
-impl<N, E, Ty: EdgeType, Ix: IndexType> Default for GraphNodeAlloc<N, E, Ty, Ix> {
+impl<N, E, Ty: EdgeType, Ix: IndexType> Default for SemiSparseGraph<N, E, Ty, Ix> {
     fn default() -> Self {
         Self::new()
     }
 }
 impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> Index<NodeIndex<Ix>>
-    for GraphNodeAlloc<N, E, Ty, Ix>
+    for SemiSparseGraph<N, E, Ty, Ix>
 {
     type Output = N::Inner;
 
@@ -262,14 +262,14 @@ impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> Index<NodeIndex<Ix>>
     }
 }
 impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> IndexMut<NodeIndex<Ix>>
-    for GraphNodeAlloc<N, E, Ty, Ix>
+    for SemiSparseGraph<N, E, Ty, Ix>
 {
     fn index_mut(&mut self, index: NodeIndex<Ix>) -> &mut Self::Output {
         self.inner[index].unwrap_mut()
     }
 }
 impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> Index<EdgeIndex<Ix>>
-    for GraphNodeAlloc<N, E, Ty, Ix>
+    for SemiSparseGraph<N, E, Ty, Ix>
 {
     type Output = E;
 
@@ -278,25 +278,25 @@ impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> Index<EdgeIndex<Ix>>
     }
 }
 impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> IndexMut<EdgeIndex<Ix>>
-    for GraphNodeAlloc<N, E, Ty, Ix>
+    for SemiSparseGraph<N, E, Ty, Ix>
 {
     fn index_mut(&mut self, index: EdgeIndex<Ix>) -> &mut Self::Output {
         &mut self.inner[index]
     }
 }
 
-impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> GraphBase for GraphNodeAlloc<N, E, Ty, Ix> {
+impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> GraphBase for SemiSparseGraph<N, E, Ty, Ix> {
     type NodeId = NodeIndex<Ix>;
     type EdgeId = EdgeIndex<Ix>;
 }
-impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> GraphProp for GraphNodeAlloc<N, E, Ty, Ix> {
+impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> GraphProp for SemiSparseGraph<N, E, Ty, Ix> {
     type EdgeType = Ty;
 }
-impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> Data for GraphNodeAlloc<N, E, Ty, Ix> {
+impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> Data for SemiSparseGraph<N, E, Ty, Ix> {
     type NodeWeight = N::Inner;
     type EdgeWeight = E;
 }
-impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> NodeIndexable for GraphNodeAlloc<N, E, Ty, Ix> {
+impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> NodeIndexable for SemiSparseGraph<N, E, Ty, Ix> {
     fn node_bound(&self) -> usize {
         self.inner.node_bound()
     }
@@ -307,7 +307,7 @@ impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> NodeIndexable for GraphNodeAll
         a.index()
     }
 }
-impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> EdgeIndexable for GraphNodeAlloc<N, E, Ty, Ix> {
+impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> EdgeIndexable for SemiSparseGraph<N, E, Ty, Ix> {
     fn edge_bound(&self) -> usize {
         self.inner.edge_bound()
     }
@@ -318,17 +318,17 @@ impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> EdgeIndexable for GraphNodeAll
         a.index()
     }
 }
-impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> NodeCount for GraphNodeAlloc<N, E, Ty, Ix> {
+impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> NodeCount for SemiSparseGraph<N, E, Ty, Ix> {
     fn node_count(&self) -> usize {
         self.node_count
     }
 }
-impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> EdgeCount for GraphNodeAlloc<N, E, Ty, Ix> {
+impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> EdgeCount for SemiSparseGraph<N, E, Ty, Ix> {
     fn edge_count(&self) -> usize {
         self.inner.edge_count()
     }
 }
-impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> DataMap for GraphNodeAlloc<N, E, Ty, Ix> {
+impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> DataMap for SemiSparseGraph<N, E, Ty, Ix> {
     fn node_weight(&self, id: Self::NodeId) -> Option<&Self::NodeWeight> {
         let w = self.inner.node_weight(id)?;
         w.is_some().then(|| w.unwrap_ref())
@@ -337,7 +337,7 @@ impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> DataMap for GraphNodeAlloc<N, 
         self.inner.edge_weight(id)
     }
 }
-impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> DataMapMut for GraphNodeAlloc<N, E, Ty, Ix> {
+impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> DataMapMut for SemiSparseGraph<N, E, Ty, Ix> {
     fn node_weight_mut(&mut self, id: Self::NodeId) -> Option<&mut Self::NodeWeight> {
         let w = self.inner.node_weight_mut(id)?;
         w.is_some().then(|| w.unwrap_mut())
@@ -347,7 +347,7 @@ impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> DataMapMut for GraphNodeAlloc<
     }
 }
 impl<N: Optional, E: Copy, Ty: EdgeType, Ix: IndexType> DataValueMap
-    for GraphNodeAlloc<N, E, Ty, Ix>
+    for SemiSparseGraph<N, E, Ty, Ix>
 where
     N::Inner: Copy,
 {
@@ -359,7 +359,7 @@ where
         self.inner.edge_weight(id).copied()
     }
 }
-impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> Visitable for GraphNodeAlloc<N, E, Ty, Ix> {
+impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> Visitable for SemiSparseGraph<N, E, Ty, Ix> {
     type Map = <Graph<N, E, Ty, Ix> as Visitable>::Map;
 
     fn visit_map(&self) -> Self::Map {
@@ -371,7 +371,7 @@ impl<N: Optional, E, Ty: EdgeType, Ix: IndexType> Visitable for GraphNodeAlloc<N
 }
 
 impl<'a, N: Optional, E, Ty: EdgeType, Ix: IndexType> IntoNodeIdentifiers
-    for &'a GraphNodeAlloc<N, E, Ty, Ix>
+    for &'a SemiSparseGraph<N, E, Ty, Ix>
 {
     type NodeIdentifiers = iter::NodeIdFilter<NodeIndices<Ix>, &'a Graph<N, E, Ty, Ix>>;
 
@@ -380,7 +380,7 @@ impl<'a, N: Optional, E, Ty: EdgeType, Ix: IndexType> IntoNodeIdentifiers
     }
 }
 impl<'a, N: Optional, E, Ty: EdgeType, Ix: IndexType> IntoNodeReferences
-    for &'a GraphNodeAlloc<N, E, Ty, Ix>
+    for &'a SemiSparseGraph<N, E, Ty, Ix>
 {
     type NodeRef = (NodeIndex<Ix>, &'a N::Inner);
     type NodeReferences = iter::NodeRefFilter<NodeReferences<'a, N, Ix>>;
@@ -390,7 +390,7 @@ impl<'a, N: Optional, E, Ty: EdgeType, Ix: IndexType> IntoNodeReferences
     }
 }
 impl<'a, N: Optional, E, Ty: EdgeType, Ix: IndexType> IntoEdgeReferences
-    for &'a GraphNodeAlloc<N, E, Ty, Ix>
+    for &'a SemiSparseGraph<N, E, Ty, Ix>
 {
     type EdgeRef = EdgeReference<'a, E, Ix>;
     type EdgeReferences = iter::EdgeRefFilter<EdgeReferences<'a, E, Ix>, &'a Graph<N, E, Ty, Ix>>;
@@ -400,7 +400,7 @@ impl<'a, N: Optional, E, Ty: EdgeType, Ix: IndexType> IntoEdgeReferences
     }
 }
 impl<'a, N: Optional, E, Ty: EdgeType, Ix: IndexType> IntoNeighbors
-    for &'a GraphNodeAlloc<N, E, Ty, Ix>
+    for &'a SemiSparseGraph<N, E, Ty, Ix>
 {
     type Neighbors = iter::NodeIdFilter<Neighbors<'a, E, Ix>, &'a Graph<N, E, Ty, Ix>>;
 
@@ -409,7 +409,7 @@ impl<'a, N: Optional, E, Ty: EdgeType, Ix: IndexType> IntoNeighbors
     }
 }
 impl<'a, N: Optional, E, Ty: EdgeType, Ix: IndexType> IntoNeighborsDirected
-    for &'a GraphNodeAlloc<N, E, Ty, Ix>
+    for &'a SemiSparseGraph<N, E, Ty, Ix>
 {
     type NeighborsDirected = iter::NodeIdFilter<Neighbors<'a, E, Ix>, &'a Graph<N, E, Ty, Ix>>;
 
@@ -418,7 +418,7 @@ impl<'a, N: Optional, E, Ty: EdgeType, Ix: IndexType> IntoNeighborsDirected
     }
 }
 impl<'a, N: Optional, E, Ty: EdgeType, Ix: IndexType> IntoEdges
-    for &'a GraphNodeAlloc<N, E, Ty, Ix>
+    for &'a SemiSparseGraph<N, E, Ty, Ix>
 {
     type Edges = iter::EdgeRefFilter<Edges<'a, E, Ty, Ix>, &'a Graph<N, E, Ty, Ix>>;
 
@@ -427,7 +427,7 @@ impl<'a, N: Optional, E, Ty: EdgeType, Ix: IndexType> IntoEdges
     }
 }
 impl<'a, N: Optional, E, Ty: EdgeType, Ix: IndexType> IntoEdgesDirected
-    for &'a GraphNodeAlloc<N, E, Ty, Ix>
+    for &'a SemiSparseGraph<N, E, Ty, Ix>
 {
     type EdgesDirected = iter::EdgeRefFilter<Edges<'a, E, Ty, Ix>, &'a Graph<N, E, Ty, Ix>>;
 


### PR DESCRIPTION
For atomic fragments in the arena, storing them as a bitset takes more space and can potentially require longer lookup times. By switching to a sparse graph that stores them contiguously, we can just store the atomic fragments as index ranges instead, which is much faster.